### PR TITLE
fix joint limits typo

### DIFF
--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -127,7 +127,7 @@
         <axis xyz="0 1 0" />
         <parent link="front_right_hip" />
         <child link="front_right_upper_leg" />
-        <limit effort="1000" velocity="1000.00" lower="-0.898845" upper="2.24506" />
+        <limit effort="1000" velocity="1000.00" lower="-0.89884456477707963539" upper="2.2951079663725435509" />
     </joint>
     <link name="front_right_lower_leg">
         <visual>


### PR DESCRIPTION
Somehow the joint limits on front-left-upper-leg's  actuator is not the same as the rest of upper-leg joints. Opening this PR in case if it's a typo error. Please disregard otherwise. 

Thank you!