### PR TITLE
Use 16UC1 instead of mono16 for depth image encoding

### DIFF
--- a/spot_driver/scripts/ros_helpers.py
+++ b/spot_driver/scripts/ros_helpers.py
@@ -141,7 +141,7 @@ def getImageMsg(data, spot_wrapper):
 
         # Little-endian uint16 z-distance from camera (mm).
         if data.shot.image.pixel_format == image_pb2.Image.PIXEL_FORMAT_DEPTH_U16:
-            image_msg.encoding = "mono16"
+            image_msg.encoding = "16UC1"
             image_msg.is_bigendian = False
             image_msg.step = 2 * data.shot.image.cols
             image_msg.data = data.shot.image.data


### PR DESCRIPTION
In this pull request, I use `16UC1` instead of `mono16` for depth image encoding.

I tried to make a pointcloud from a depth image using `depth_image_proc`, but I couldn't do it due to encoding problems.
For depth images, encoding such as `mono8` or `mono16` is not supported.
https://github.com/ros-perception/image_pipeline/blob/91392f9cdb410f9baf1a4914752271be3eea21f9/depth_image_proc/src/nodelets/point_cloud_xyz.cpp#L117

This is because "mono" represents a monochromatic image.
Please see [this comment](https://github.com/ros-perception/vision_opencv/issues/175#issuecomment-314099859) for a detailed explanation.