### PR TITLE
[spot_driver] add python3-rospkg-modules dependency

### DIFF
--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>
+  <exec_depend>python3-rospkg-modules</exec_depend>
   <exec_depend>twist_mux</exec_depend>
   <exec_depend>interactive_marker_twist_server</exec_depend>
 


### PR DESCRIPTION
added python3-rospkg-modules key to the package.xml of spot_driver for executing of ros python3 scripts