### PR TITLE
Queue size change for cmd_vel and body_pose subscribers.

### DIFF
--- a/spot_driver/scripts/spot_ros.py
+++ b/spot_driver/scripts/spot_ros.py
@@ -361,8 +361,8 @@ class SpotROS():
 
             self.feedback_pub = rospy.Publisher('status/feedback', Feedback, queue_size=10)
 
-            rospy.Subscriber('cmd_vel', Twist, self.cmdVelCallback)
-            rospy.Subscriber('body_pose', Pose, self.bodyPoseCallback)
+            rospy.Subscriber('cmd_vel', Twist, self.cmdVelCallback, queue_size = 1)
+            rospy.Subscriber('body_pose', Pose, self.bodyPoseCallback, queue_size = 1)
 
             rospy.Service("claim", Trigger, self.handle_claim)
             rospy.Service("release", Trigger, self.handle_release)


### PR DESCRIPTION
The cmd_vel topic currently has an infinite queue size which can create significant lag when running an external controller. This is especially prevalent when many other processes are running on the robot and the computer is not keeping up with the queue. The result is the Spot continues to move until the queue is processed even if an external controller is telling the spot not to move. By changing the queue size to 1 this problem is mitigated, and the Spot is much more responsive regardless of any other processes running on the computer. The same problem can occur with the body pose subscriber.