### PR TITLE
Add missing assignment to w field of quaternion

### DIFF
--- a/spot_driver/scripts/ros_helpers.py
+++ b/spot_driver/scripts/ros_helpers.py
@@ -295,6 +295,8 @@ def GetOdomFromState(state, spot_wrapper, use_vision=True):
     pose_odom_msg.pose.orientation.x = tform_body.rotation.x
     pose_odom_msg.pose.orientation.y = tform_body.rotation.y
     pose_odom_msg.pose.orientation.z = tform_body.rotation.z
+    pose_odom_msg.pose.orientation.w = tform_body.rotation.w
+
     odom_msg.pose = pose_odom_msg
     twist_odom_msg = GetOdomTwistFromState(state, spot_wrapper).twist
     odom_msg.twist = twist_odom_msg


### PR DESCRIPTION
`GetOdomFromState` missed assigning the `w` field of the odometry quaternion which caused strange appearance of the robot state if the odometry topic was used to visualise the robot.