### PR TITLE
Fix image format and include graph_nav_util in install

### DIFF
--- a/spot_driver/CMakeLists.txt
+++ b/spot_driver/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(
 
 catkin_install_python(
 	PROGRAMS
+	  scripts/graph_nav_util.py
 	  scripts/ros_helpers.py
 	  scripts/spot_ros.py
 	  scripts/spot_wrapper.py

--- a/spot_driver/scripts/spot_wrapper.py
+++ b/spot_driver/scripts/spot_wrapper.py
@@ -213,15 +213,15 @@ class SpotWrapper():
 
         self._front_image_requests = []
         for source in front_image_sources:
-            self._front_image_requests.append(build_image_request(source, image_format=image_pb2.Image.Format.FORMAT_RAW))
+            self._front_image_requests.append(build_image_request(source, image_format=image_pb2.Image.FORMAT_RAW))
 
         self._side_image_requests = []
         for source in side_image_sources:
-            self._side_image_requests.append(build_image_request(source, image_format=image_pb2.Image.Format.FORMAT_RAW))
+            self._side_image_requests.append(build_image_request(source, image_format=image_pb2.Image.FORMAT_RAW))
 
         self._rear_image_requests = []
         for source in rear_image_sources:
-            self._rear_image_requests.append(build_image_request(source, image_format=image_pb2.Image.Format.FORMAT_RAW))
+            self._rear_image_requests.append(build_image_request(source, image_format=image_pb2.Image.FORMAT_RAW))
 
         try:
             self._sdk = create_standard_sdk('ros_spot')


### PR DESCRIPTION
I was getting an attribute error when running spot_ros, caused by what seems to be an incorrect usage of `image_pb2.Image.Format.IMAGE_RAW`. The use of `Image.Format` is not present in other places in the code, and this updates the spot_wrapper to be consistent with the other usages.

This also adds the graph_nav_util file to the catkin_python_install as it seems this being missing can cause issues.