### PR TITLE
Allow non-synchro versions of stand/sit/velocity to support older spot software versions

### DIFF
--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -483,12 +483,22 @@ class SpotWrapper():
     def sit(self):
         """Stop the robot's motion and sit down if able."""
         response = self._robot_command(RobotCommandBuilder.synchro_sit_command())
+        if "UnsupportedError" in response[1]:
+            self._logger.warn("Call to synchro_sit_command failed - you are likely on an old version of spot "
+                              "software. Trying deprecated (since 2.1.0) sit_command instead. The specific error was:\n"
+                              "{}".format(response[1]))
+            response = self._robot_command(RobotCommandBuilder.sit_command())
         self._last_sit_command = response[2]
         return response[0], response[1]
 
     def stand(self, monitor_command=True):
         """If the e-stop is enabled, and the motor power is enabled, stand the robot up."""
         response = self._robot_command(RobotCommandBuilder.synchro_stand_command(params=self._mobility_params))
+        if "UnsupportedError" in response[1]:
+            self._logger.warn("Call to synchro_stand_command failed - you are likely on an old version of spot "
+                              "software. Trying deprecated (since 2.1.0) stand_command instead. The specific error "
+                              "was:\n{}".format(response[1]))
+            response = self._robot_command(RobotCommandBuilder.stand_command())
         if monitor_command:
             self._last_stand_command = response[2]
         return response[0], response[1]
@@ -540,6 +550,14 @@ class SpotWrapper():
         response = self._robot_command(RobotCommandBuilder.synchro_velocity_command(
                                       v_x=v_x, v_y=v_y, v_rot=v_rot, params=self._mobility_params),
                                       end_time_secs=end_time, timesync_endpoint=self._robot.time_sync.endpoint)
+        if "UnsupportedError" in response[1]:
+            self._logger.warn("Call to synchro_velocity_command failed - you are likely on an old version of spot "
+                              "software. Trying deprecated (since 2.1.0) velocity_command instead. The specific error "
+                              "was:\n{}".format(response[1]))
+            response = self._robot_command(RobotCommandBuilder.velocity_command(
+                                          v_x=v_x, v_y=v_y, v_rot=v_rot, params=self._mobility_params),
+                                          end_time_secs=end_time, timesync_endpoint=self._robot.time_sync.endpoint)
+
         self._last_velocity_command_time = end_time
         return response[0], response[1]
 


### PR DESCRIPTION
The spot that we are currently using is on version 2.0.1 of the software. Because of this, the stand, sit, and velocity commands do not work. We receive

```
bosdyn.api.RobotCommandResponse (UnsupportedError): The API supports this request, but the system does not support this request.
```

This is due to the synchro versions of the commands not being present in that version of the software.

This PR will check if `UnsupportedError` is received for sit/stand/velocity commands, and try the deprecated non-synchro versions of the commands. This is required for robots running lower software versions to use these commands. 

Ideally the sit/stand/velocity functions would catch this exception but it's already caught by the `_robot_command` function so rather than changing that I'm just using string comparisions.

This PR allows users on old spot versions to use this driver.

When running, you will see quite obnoxious warnings on the terminal:

```
[WARN] [1621346522.319741]: Call to synchro_stand_command failed - you are likely on an old version of spot software. Trying deprecated (since 2.1.0) stand_command instead. The specific error was bosdyn.api.Robot
CommandResponse (UnsupportedError): The API supports this request, but the system does not support this request.
/home/spot/spot_ws/src/spot_ros/spot_driver/src/spot_driver/spot_wrapper.py:500: DeprecationWarning: Call to deprecated function (or staticmethod) stand_command. (Mobility commands are now sent as a part of synch
ronized commands. Use synchro_stand_command instead.) -- Deprecated since version 2.1.0.                  
  response = self._robot_command(RobotCommandBuilder.stand_command())                                     
[WARN] [1621346535.097399]: Call to synchro_sit_command failed - you are likely on an old version of spot software. Trying deprecated (since 2.1.0) sit_command instead. The specific error was bosdyn.api.RobotComm
andResponse (UnsupportedError): The API supports this request, but the system does not support this request.
/home/spot/spot_ws/src/spot_ros/spot_driver/src/spot_driver/spot_wrapper.py:489: DeprecationWarning: Call to deprecated function (or staticmethod) sit_command. (Mobility commands are now sent as a part of synchro
nized commands. Use synchro_sit_command instead.) -- Deprecated since version 2.1.0.                      
  response = self._robot_command(RobotCommandBuilder.sit_command())                                       
[WARN] [1621347270.956642]: Call to synchro_stand_command failed - you are likely on an old version of spot software. Trying deprecated (since 2.1.0) stand_command instead. The specific error was bosdyn.api.Robot
CommandResponse (UnsupportedError): The API supports this request, but the system does not support this request.
/home/spot/spot_ws/src/spot_ros/spot_driver/src/spot_driver/spot_wrapper.py:500: DeprecationWarning: Call to deprecated function (or staticmethod) stand_command. (Mobility commands are now sent as a part of synch
ronized commands. Use synchro_stand_command instead.) -- Deprecated since version 2.1.0.                  
  response = self._robot_command(RobotCommandBuilder.stand_command())                                     
[WARN] [1621347314.222499]: Call to synchro_velocity_command failed - you are likely on an old version of spot software. Trying deprecated (since 2.1.0) velocity_command instead. The specific error was bosdyn.api
.RobotCommandResponse (UnsupportedError): The API supports this request, but the system does not support this request.
/home/spot/spot_ws/src/spot_ros/spot_driver/src/spot_driver/spot_wrapper.py:556: DeprecationWarning: Call to deprecated function (or staticmethod) velocity_command. (Mobility commands are now sent as a part of sy
nchronized commands. Use synchro_velocity_command instead.) -- Deprecated since version 2.1.0.            
  response = self._robot_command(RobotCommandBuilder.velocity_command(                                    
[WARN] [1621347430.643486]: Call to synchro_velocity_command failed - you are likely on an old version of spot software. Trying deprecated (since 2.1.0) velocity_command instead. The specific error was bosdyn.api
.RobotCommandResponse (UnsupportedError): The API supports this request, but the system does not support this request.
/home/spot/spot_ws/src/spot_ros/spot_driver/src/spot_driver/spot_wrapper.py:556: DeprecationWarning: Call to deprecated function (or staticmethod) velocity_command. (Mobility commands are now sent as a part of sy
nchronized commands. Use synchro_velocity_command instead.) -- Deprecated since version 2.1.0.            
  response = self._robot_command(RobotCommandBuilder.velocity_command(                                    
[WARN] [1621347448.546314]: Call to synchro_sit_command failed - you are likely on an old version of spot software. Trying deprecated (since 2.1.0) sit_command instead. The specific error was bosdyn.api.RobotComm
andResponse (UnsupportedError): The API supports this request, but the system does not support this request.
/home/spot/spot_ws/src/spot_ros/spot_driver/src/spot_driver/spot_wrapper.py:489: DeprecationWarning: Call to deprecated function (or staticmethod) sit_command. (Mobility commands are now sent as a part of synchro
nized commands. Use synchro_sit_command instead.) -- Deprecated since version 2.1.0.                      
  response = self._robot_command(RobotCommandBuilder.sit_command())
```

Which is a good reminder that you should probably update your software version (if you can).

Perhaps it would be better to have the user explicitly specify that they want to enable these old commands. If so, I can add a flag like `enable_deprecated_motion_commands` to the launch file.

I'd also understand if you don't want to include this at all given that its inclusion may discourage transition to newer software versions.