### PR TITLE
E-Stop not engaging properly fix

### DIFF
--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -281,6 +281,11 @@ class SpotROS():
         resp = self.spot_wrapper.assertEStop(False)
         return TriggerResponse(resp[0], resp[1])
 
+    def handle_estop_disengage(self, req):
+        """ROS service handler to disengage the eStop on the robot."""
+        resp = self.spot_wrapper.disengageEStop()
+        return TriggerResponse(resp[0], resp[1])
+
     def handle_clear_bahavior_fault(self, req):
         """ROS service handler for clearing behavior faults"""
         resp = self.spot_wrapper.clear_behavior_fault(req.id)
@@ -545,6 +550,8 @@ class SpotROS():
 
             rospy.Service("estop/hard", Trigger, self.handle_estop_hard)
             rospy.Service("estop/gentle", Trigger, self.handle_estop_soft)
+            rospy.Service("estop/release", Trigger, self.handle_estop_disengage)
+
 
             rospy.Service("stair_mode", SetBool, self.handle_stair_mode)
             rospy.Service("locomotion_mode", SetLocomotion, self.handle_locomotion_mode)

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -414,13 +414,22 @@ class SpotWrapper():
         """
         try:
             if severe:
-                self._estop_endpoint.stop()
+                self._estop_keepalive.stop()
             else:
-                self._estop_endpoint.settle_then_cut()
+                self._estop_keepalive.settle_then_cut()
 
             return True, "Success"
         except:
             return False, "Error"
+
+    def disengageEStop(self):
+        """Disengages the E-Stop"""
+        try:
+            self._estop_keepalive.allow()
+            return True, "Success"
+        except:
+            return False, "Error"
+
 
     def releaseEStop(self):
         """Stop eStop keepalive"""


### PR DESCRIPTION
This pull request fixes an issue where the software E-Stop on the Spot would not properly engage. Previously when calling either the estop/gentle or estop/hard service the Spot would sit down and act like it was E-Stopped. However, if a new cmd_vel was issued the robot would get up and move. This was also highlighted in the E-Stop status message where the software E-Stop would stay in the STATE_NOT_ESTOPPED (2) state.

It appears the root cause for this issue was directly calling the endpoint for the E-Stop instead of the KeepAlive client. The Boston Dynamics API (https://dev.bostondynamics.com/python/bosdyn-client/src/bosdyn/client/estop#bosdyn.client.estop.EstopKeepAlive) advises only accessing the KeepAlive client and not the endpoint. Changing this call makes the E-Stop stop the robot until it is released. The status is also appropriately updated.

This change also required adding a hook to release the E-Stop. I added a new service (estop/release) to release the E-Stop which calls the allow method on the KeepAlive client to disengage the E-Stop.