### PR TITLE
Refactor waypoint navigation function

### DIFF
--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -31,7 +31,12 @@ from spot_msgs.msg import Feedback
 from spot_msgs.msg import MobilityParams
 from spot_msgs.msg import NavigateToAction, NavigateToResult, NavigateToFeedback
 from spot_msgs.msg import TrajectoryAction, TrajectoryResult, TrajectoryFeedback
-from spot_msgs.srv import ListGraph, ListGraphResponse, SetLocomotion, SetLocomotionResponse, ClearBehaviorFault, ClearBehaviorFaultResponse
+from spot_msgs.srv import ListGraph, ListGraphResponse
+from spot_msgs.srv import UploadGraph, UploadGraphResponse
+from spot_msgs.srv import SetLocalizationFiducial, SetLocalizationFiducialResponse
+from spot_msgs.srv import SetLocalizationWaypoint, SetLocalizationWaypointResponse
+from spot_msgs.srv import SetLocomotion, SetLocomotionResponse
+from spot_msgs.srv import ClearBehaviorFault, ClearBehaviorFaultResponse
 
 from .ros_helpers import *
 from .spot_wrapper import SpotWrapper
@@ -385,10 +390,25 @@ class SpotROS():
         mobility_params.body_control.CopyFrom(body_control)
         self.spot_wrapper.set_mobility_params(mobility_params)
 
-    def handle_list_graph(self, upload_path):
+    def handle_list_graph(self, req):
         """ROS service handler for listing graph_nav waypoint_ids"""
-        resp = self.spot_wrapper.list_graph(upload_path)
+        resp = self.spot_wrapper.list_graph()
         return ListGraphResponse(resp)
+
+    def handle_upload_graph(self, req):
+        """"""
+        resp = self.spot_wrapper.upload_graph(req.upload_filepath)
+        return UploadGraphResponse(resp[0], resp[1])
+
+    def handle_set_localization_fiducial(self, req):
+        """"""
+        resp = self.spot_wrapper.set_localization_fiducial()
+        return SetLocalizationFiducialResponse(resp[0], resp[1])
+
+    def handle_set_localization_waypoint(self, req):
+        """"""
+        resp = self.spot_wrapper.set_localization_waypoint(req.waypoint_id)
+        return SetLocalizationWaypointResponse(resp[0], resp[1])
 
     def handle_navigate_to_feedback(self):
         """Thread function to send navigate_to feedback"""
@@ -405,10 +425,7 @@ class SpotROS():
         self.run_navigate_to = True
         feedback_thraed.start()
         # run navigate_to
-        resp = self.spot_wrapper.navigate_to(upload_path = msg.upload_path,
-                                             navigate_to = msg.navigate_to,
-                                             initial_localization_fiducial = msg.initial_localization_fiducial,
-                                             initial_localization_waypoint = msg.initial_localization_waypoint)
+        resp = self.spot_wrapper.navigate_to(id_navigate_to = msg.id_navigate_to)
         self.run_navigate_to = False
         feedback_thraed.join()
 
@@ -557,7 +574,10 @@ class SpotROS():
             rospy.Service("locomotion_mode", SetLocomotion, self.handle_locomotion_mode)
             rospy.Service("clear_behavior_fault", ClearBehaviorFault, self.handle_clear_bahavior_fault)
 
+            rospy.Service("upload_graph", UploadGraph, self.handle_upload_graph)
             rospy.Service("list_graph", ListGraph, self.handle_list_graph)
+            rospy.Service("set_localization_fiducial", SetLocalizationFiducial, self.handle_set_localization_fiducial)
+            rospy.Service("set_localization_waypoint", SetLocalizationWaypoint, self.handle_set_localization_waypoint)
 
             self.navigate_as = actionlib.SimpleActionServer('navigate_to', NavigateToAction,
                                                             execute_cb = self.handle_navigate_to,

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -37,8 +37,11 @@ add_message_files(
 add_service_files(
   FILES
   ListGraph.srv
+  SetLocalizationFiducial.srv
+  SetLocalizationWaypoint.srv
   SetLocomotion.srv
   ClearBehaviorFault.srv
+  UploadGraph.srv
 )
 
 add_action_files(

--- a/spot_msgs/action/NavigateTo.action
+++ b/spot_msgs/action/NavigateTo.action
@@ -1,7 +1,4 @@
-string upload_path # Absolute path to map_directory, which is downloaded from tablet controller
-string navigate_to # Waypoint id string for where to go
-bool initial_localization_fiducial   # Tells the initializer whether to use fiducials
-string initial_localization_waypoint # Waypoint id to trigger localization 
+string id_navigate_to # Waypoint id string for where to go
 ---
 bool success   # indicate successful run of triggered service
 string message # informational, e.g. for error messages

--- a/spot_msgs/srv/ListGraph.srv
+++ b/spot_msgs/srv/ListGraph.srv
@@ -1,4 +1,2 @@
-string upload_filepath
 ---
 string[] waypoint_ids
-

--- a/spot_msgs/srv/SetLocalizationFiducial.srv
+++ b/spot_msgs/srv/SetLocalizationFiducial.srv
@@ -1,0 +1,3 @@
+---
+bool success
+string message

--- a/spot_msgs/srv/SetLocalizationWaypoint.srv
+++ b/spot_msgs/srv/SetLocalizationWaypoint.srv
@@ -1,0 +1,4 @@
+string waypoint_id
+---
+bool success
+string message

--- a/spot_msgs/srv/UploadGraph.srv
+++ b/spot_msgs/srv/UploadGraph.srv
@@ -1,0 +1,4 @@
+string upload_filepath
+---
+bool success
+string message


### PR DESCRIPTION
Current navigation requires re-upload graph every time you set a new navigation ID. This is quite time-consuming when you use the same graph (more than 30 second for a 50 meter path).  

Thus, we 
- implement independent graph uploading service `/spot/upload_graph`  to avoid reuploading same graph when set navigate_id.
- implement independent localization service (`/spot/set_localization_waypoint` and `/spot/set_localization_fiducial`) and navigation function `/spot/navigate_to/goal`