### PR TITLE
can require trajectory commands to reach goal precisely

### DIFF
--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -179,16 +179,20 @@ class AsyncIdle(AsyncPeriodicQuery):
         if self._spot_wrapper._last_trajectory_command != None:
             try:
                 response = self._client.robot_command_feedback(self._spot_wrapper._last_trajectory_command)
-                if (response.feedback.synchronized_feedback.mobility_command_feedback.se2_trajectory_feedback.status ==
-                    basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_GOING_TO_GOAL):
-                    is_moving = True
-                elif (response.feedback.synchronized_feedback.mobility_command_feedback.se2_trajectory_feedback.status ==
-                    basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_AT_GOAL) or \
-                     (response.feedback.synchronized_feedback.mobility_command_feedback.se2_trajectory_feedback.status ==
-                    basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_NEAR_GOAL):
+                status = response.feedback.synchronized_feedback.mobility_command_feedback.se2_trajectory_feedback.status
+                # STATUS_AT_GOAL always means that the robot reached the goal. If the trajectory command did not
+                # request precise positioning, then STATUS_NEAR_GOAL also counts as reaching the goal
+                if status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_AT_GOAL or \
+                    (status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_NEAR_GOAL and
+                     not self._spot_wrapper._last_trajectory_command_precise):
                     self._spot_wrapper._at_goal = True
                     # Clear the command once at the goal
                     self._spot_wrapper._last_trajectory_command = None
+                elif status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_GOING_TO_GOAL:
+                    is_moving = True
+                elif status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_NEAR_GOAL:
+                    is_moving = True
+                    self._spot_wrapper._near_goal = True
                 else:
                     self._spot_wrapper._last_trajectory_command = None
             except (ResponseError, RpcError) as e:
@@ -217,9 +221,11 @@ class SpotWrapper():
         self._is_sitting = True
         self._is_moving = False
         self._at_goal = False
+        self._near_goal = False
         self._last_stand_command = None
         self._last_sit_command = None
         self._last_trajectory_command = None
+        self._last_trajectory_command_precise = None
         self._last_velocity_command_time = None
 
         self._front_image_requests = []
@@ -351,6 +357,10 @@ class SpotWrapper():
     def is_moving(self):
         """Return boolean of walking state"""
         return self._is_moving
+
+    @property
+    def near_goal(self):
+        return self._near_goal
 
     @property
     def at_goal(self):
@@ -552,7 +562,7 @@ class SpotWrapper():
         self._last_velocity_command_time = end_time
         return response[0], response[1]
 
-    def trajectory_cmd(self, goal_x, goal_y, goal_heading, cmd_duration, frame_name='odom'):
+    def trajectory_cmd(self, goal_x, goal_y, goal_heading, cmd_duration, frame_name='odom', precise_position=False):
         """Send a trajectory motion command to the robot.
 
         Args:
@@ -561,8 +571,13 @@ class SpotWrapper():
             goal_heading: Pose heading in radians
             cmd_duration: Time-to-live for the command in seconds.
             frame_name: frame_name to be used to calc the target position. 'odom' or 'vision'
+            precise_position: if set to false, the status STATUS_NEAR_GOAL and STATUS_AT_GOAL will be equivalent. If
+            true, the robot must complete its final positioning before it will be considered to have successfully
+            reached the goal.
         """
         self._at_goal = False
+        self._near_goal = False
+        self._last_trajectory_command_precise = precise_position
         self._logger.info("got command duration of {}".format(cmd_duration))
         end_time=time.time() + cmd_duration
         if frame_name == 'vision':

--- a/spot_msgs/action/Trajectory.action
+++ b/spot_msgs/action/Trajectory.action
@@ -1,5 +1,12 @@
 geometry_msgs/PoseStamped target_pose
+# After this duration, the command will time out and the robot will stop. Must be non-zero
 std_msgs/Duration duration
+# If true, the feedback from the trajectory command must indicate that the robot is
+# at the goal position. If set to false, the robot being near the goal is equivalent to
+# it being at the goal. This is based on the feedback received from the boston dynamics
+# API call at
+# https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference.html?highlight=status_near_goal#se2trajectorycommand-feedback-status
+bool precise_positioning
 ---
 bool success
 string message


### PR DESCRIPTION
Add precise_positioning field to the trajectory goal. Setting to true will make the wrapper consider only STATUS_AT_GOAL status to mean that the robot is at the goal. Setting to false will replicate previous behaviour where STATUS_NEAR_GOAL also means that the robot is at the goal.

Vary feedback messages from the driver depending on whether the precise positioning field was set.

To test, you can use `rosrun actionlib_tools axclient /spot/trajectory`. Enter something like

```
target_pose: 
  header: 
    seq: 0
    stamp: 
      secs: 0
      nsecs:         0
    frame_id: 'body'
  pose: 
    position: 
      x: 0.5
      y: 0.0
      z: 0.0
    orientation: 
      x: 0.0
      y: 0.0
      z: 0.0
      w: 1
duration: 
  data: 
    secs: 4
    nsecs:         0
precise_positioning: True
```

Into the goal. When precise positioning is not set, the robot will stop vaguely in the vicinity of the goal, but if it is set the positioning will be much more precise.