### PR TITLE
Simple rviz panel for interaction with spot

### DIFF
--- a/spot_viz/CMakeLists.txt
+++ b/spot_viz/CMakeLists.txt
@@ -1,13 +1,40 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(spot_viz)
 
-find_package(catkin REQUIRED COMPONENTS)
+find_package(catkin REQUIRED COMPONENTS rviz)
 
 catkin_package()
+
+set(CMAKE_AUTOMOC ON)
+
+if(rviz_QT_VERSION VERSION_LESS "5")
+  message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
+  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
+  include(${QT_USE_FILE})
+else()
+  message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
+  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets UiTools)
+  set(QT_LIBRARIES Qt5::Widgets Qt5::UiTools)
+endif()
 
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
+set(SRC_FILES
+  src/spot_panel.cpp
+)
+
+add_library(${PROJECT_NAME} ${SRC_FILES})
+target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${catkin_LIBRARIES})
+
+install(TARGETS
+  ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 install(DIRECTORY rviz DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+install(FILES plugin_description.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/spot_viz/package.xml
+++ b/spot_viz/package.xml
@@ -10,10 +10,17 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>qtbase5-dev</build_depend>
+  <build_depend>rviz</build_depend>
+
+  <exec_depend>libqt5-core</exec_depend>
+  <exec_depend>libqt5-gui</exec_depend>
+  <exec_depend>libqt5-widgets</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>rviz</exec_depend>
 
   <export>
+      <rviz plugin="${prefix}/plugin_description.xml"/>
   </export>
 </package>

--- a/spot_viz/plugin_description.xml
+++ b/spot_viz/plugin_description.xml
@@ -1,0 +1,9 @@
+<library path="lib/libspot_viz">
+  <class name="spot_viz/SpotControlPanel"
+         type="spot_viz::ControlPanel"
+         base_class_type="rviz::Panel">
+    <description>
+      A panel for controlling the Boston Dynamics Spot robot with the Clearpath driver
+    </description>
+  </class>
+</library>

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>456</width>
+    <height>618</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="claimLayout">
+       <item>
+        <widget class="QPushButton" name="claimLeaseButton">
+         <property name="text">
+          <string>Claim Lease</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="releaseLeaseButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Release Lease</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="powerLayout">
+       <item>
+        <widget class="QPushButton" name="powerOnButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Power On</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="powerOffButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Power Off</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="sitStandLayout">
+       <item>
+        <widget class="QPushButton" name="sitButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Sit</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="standButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Stand</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QGridLayout" name="bodyPoseGridLayout">
+       <item row="1" column="0" colspan="2">
+        <widget class="QLabel" name="bodyPoseLabel">
+         <property name="text">
+          <string>Body Pose Control</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="rollLabel">
+         <property name="text">
+          <string>Roll</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="yawLabel">
+         <property name="text">
+          <string>Yaw</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0" colspan="2">
+        <widget class="QPushButton" name="setBodyPoseButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Set Body Pose</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="pitchLabel">
+         <property name="text">
+          <string>Pitch</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="bodyHeightLabel">
+         <property name="text">
+          <string>Body height</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QDoubleSpinBox" name="bodyHeightSpin">
+         <property name="buttonSymbols">
+          <enum>QAbstractSpinBox::NoButtons</enum>
+         </property>
+         <property name="decimals">
+          <number>2</number>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QDoubleSpinBox" name="rollSpin">
+         <property name="buttonSymbols">
+          <enum>QAbstractSpinBox::NoButtons</enum>
+         </property>
+         <property name="decimals">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QDoubleSpinBox" name="pitchSpin">
+         <property name="buttonSymbols">
+          <enum>QAbstractSpinBox::NoButtons</enum>
+         </property>
+         <property name="decimals">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QDoubleSpinBox" name="yawSpin">
+         <property name="buttonSymbols">
+          <enum>QAbstractSpinBox::NoButtons</enum>
+         </property>
+         <property name="decimals">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QLabel" name="statusLabel">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/spot_viz/rviz/robot.rviz
+++ b/spot_viz/rviz/robot.rviz
@@ -7,7 +7,7 @@ Panels:
         - /Global Options1
         - /Status1
       Splitter Ratio: 0.5
-    Tree Height: 853
+    Tree Height: 437
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -16,7 +16,7 @@ Panels:
       - /2D Nav Goal1
       - /Publish Point1
     Name: Tool Properties
-    Splitter Ratio: 0.588679016
+    Splitter Ratio: 0.5886790156364441
   - Class: rviz/Views
     Expanded:
       - /Current View1
@@ -26,7 +26,11 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: FrontLeftDepthCloud
+    SyncSource: ""
+  - Class: spot_viz/SpotControlPanel
+    Name: SpotControlPanel
+Preferences:
+  PromptSaveOnExit: true
 Toolbars:
   toolButtonStyle: 2
 Visualization Manager:
@@ -38,7 +42,7 @@ Visualization Manager:
       Color: 160; 160; 164
       Enabled: true
       Line Style:
-        Line Width: 0.0299999993
+        Line Width: 0.029999999329447746
         Value: Lines
       Name: Grid
       Normal Cell Count: 0
@@ -60,71 +64,6 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
-        body:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        front_left_hip:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        front_left_lower_leg:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        front_left_upper_leg:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        front_right_hip:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        front_right_lower_leg:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        front_right_upper_leg:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        rear_left_hip:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        rear_left_lower_leg:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        rear_left_upper_leg:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        rear_right_hip:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        rear_right_lower_leg:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        rear_right_upper_leg:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
       Name: RobotModel
       Robot Description: robot_description
       TF Prefix: ""
@@ -136,104 +75,14 @@ Visualization Manager:
       Frame Timeout: 15
       Frames:
         All Enabled: true
-        back:
-          Value: true
-        back_fisheye:
-          Value: true
-        body:
-          Value: true
-        front_left_hip:
-          Value: true
-        front_left_lower_leg:
-          Value: true
-        front_left_upper_leg:
-          Value: true
-        front_right_hip:
-          Value: true
-        front_right_lower_leg:
-          Value: true
-        front_right_upper_leg:
-          Value: true
-        frontleft:
-          Value: true
-        frontleft_fisheye:
-          Value: true
-        frontright:
-          Value: true
-        frontright_fisheye:
-          Value: true
-        gpe:
-          Value: true
-        head:
-          Value: true
-        left:
-          Value: true
-        left_fisheye:
-          Value: true
-        odom:
-          Value: true
-        rear_left_hip:
-          Value: true
-        rear_left_lower_leg:
-          Value: true
-        rear_left_upper_leg:
-          Value: true
-        rear_right_hip:
-          Value: true
-        rear_right_lower_leg:
-          Value: true
-        rear_right_upper_leg:
-          Value: true
-        right:
-          Value: true
-        right_fisheye:
-          Value: true
-        vision:
-          Value: true
+      Marker Alpha: 1
       Marker Scale: 0.25
       Name: TF
       Show Arrows: true
       Show Axes: true
       Show Names: true
       Tree:
-        body:
-          front_left_hip:
-            front_left_upper_leg:
-              front_left_lower_leg:
-                {}
-          front_right_hip:
-            front_right_upper_leg:
-              front_right_lower_leg:
-                {}
-          head:
-            back:
-              back_fisheye:
-                {}
-            frontleft:
-              frontleft_fisheye:
-                {}
-            frontright:
-              frontright_fisheye:
-                {}
-            left:
-              left_fisheye:
-                {}
-            right:
-              right_fisheye:
-                {}
-          odom:
-            gpe:
-              {}
-          rear_left_hip:
-            rear_left_upper_leg:
-              rear_left_lower_leg:
-                {}
-          rear_right_hip:
-            rear_right_upper_leg:
-              rear_right_lower_leg:
-                {}
-          vision:
-            {}
+        {}
       Update Interval: 0
       Value: true
     - Class: rviz/Group
@@ -244,8 +93,8 @@ Visualization Manager:
             Value: true
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 2.45363283
-            Min Value: -0.155580759
+            Max Value: 2.4536328315734863
+            Min Value: -0.15558075904846191
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -260,9 +109,7 @@ Visualization Manager:
           Enabled: true
           Invert Rainbow: false
           Max Color: 255; 255; 255
-          Max Intensity: 4096
           Min Color: 0; 0; 0
-          Min Intensity: 0
           Name: FrontLeftDepthCloud
           Occlusion Compensation:
             Occlusion Time-Out: 30
@@ -282,8 +129,8 @@ Visualization Manager:
             Value: true
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 2.612113
-            Min Value: -0.112739921
+            Max Value: 2.6121129989624023
+            Min Value: -0.1127399206161499
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -298,9 +145,7 @@ Visualization Manager:
           Enabled: true
           Invert Rainbow: false
           Max Color: 255; 255; 255
-          Max Intensity: 4096
           Min Color: 0; 0; 0
-          Min Intensity: 0
           Name: FrontRightDepthCloud
           Occlusion Compensation:
             Occlusion Time-Out: 30
@@ -320,8 +165,8 @@ Visualization Manager:
             Value: true
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 1.41352618
-            Min Value: -0.128979474
+            Max Value: 1.413526177406311
+            Min Value: -0.12897947430610657
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -336,9 +181,7 @@ Visualization Manager:
           Enabled: true
           Invert Rainbow: false
           Max Color: 255; 255; 255
-          Max Intensity: 4096
           Min Color: 0; 0; 0
-          Min Intensity: 0
           Name: LeftDepthCloud
           Occlusion Compensation:
             Occlusion Time-Out: 30
@@ -358,8 +201,8 @@ Visualization Manager:
             Value: true
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 1.45274436
-            Min Value: -0.124786079
+            Max Value: 1.4527443647384644
+            Min Value: -0.12478607892990112
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -374,9 +217,7 @@ Visualization Manager:
           Enabled: true
           Invert Rainbow: false
           Max Color: 255; 255; 255
-          Max Intensity: 4096
           Min Color: 0; 0; 0
-          Min Intensity: 0
           Name: RightDepthCloud
           Occlusion Compensation:
             Occlusion Time-Out: 30
@@ -396,8 +237,8 @@ Visualization Manager:
             Value: true
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 0.655641437
-            Min Value: -0.0852906406
+            Max Value: 0.6556414365768433
+            Min Value: -0.08529064059257507
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -412,9 +253,7 @@ Visualization Manager:
           Enabled: true
           Invert Rainbow: false
           Max Color: 255; 255; 255
-          Max Intensity: 4096
           Min Color: 0; 0; 0
-          Min Intensity: 0
           Name: RearDepthCloud
           Occlusion Compensation:
             Occlusion Time-Out: 30
@@ -444,6 +283,7 @@ Visualization Manager:
       Frame Timeout: 15
       Frames:
         All Enabled: true
+      Marker Alpha: 1
       Marker Scale: 1
       Name: TF
       Show Arrows: true
@@ -468,7 +308,10 @@ Visualization Manager:
     - Class: rviz/FocusCamera
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
       Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
     - Class: rviz/SetGoal
       Topic: /move_base_simple/goal
     - Class: rviz/PublishPoint
@@ -478,34 +321,36 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 4.59715652
+      Distance: 4.597156524658203
       Enable Stereo Rendering:
-        Stereo Eye Separation: 0.0599999987
+        Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
+      Field of View: 0.7853981852531433
       Focal Point:
-        X: -0.143477932
-        Y: 0.615365922
-        Z: 0.880245864
+        X: -0.1434779316186905
+        Y: 0.6153659224510193
+        Z: 0.8802458643913269
       Focal Shape Fixed Size: false
-      Focal Shape Size: 0.0500000007
+      Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
-      Near Clip Distance: 0.00999999978
-      Pitch: 0.530398846
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.5303988456726074
       Target Frame: <Fixed Frame>
-      Value: Orbit (rviz)
-      Yaw: 4.32234859
+      Yaw: 4.322348594665527
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1056
+  Height: 1016
   Hide Left Dock: false
   Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd0000000400000000000002ad00000396fc0200000011fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002800000396000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000280020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006700000002300000018e0000000000000000fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000000a0049006d00610067006501000002f4000000ca0000000000000000fb0000000a0049006d00610067006501000002f4000000ca0000000000000000fb0000000a0049006d006100670065000000013f000000660000000000000000fb0000000a0049006d0061006700650000000164000000940000000000000000fb0000000a0049006d00610067006500000001a3000000e80000000000000000fc00000227000001970000000000fffffffa000000000100000002fb0000000a0049006d0061006700650000000000ffffffff0000000000000000fb0000000a0049006d0061006700650000000000000002ad0000000000000000000000010000010f00000396fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002800000396000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000073f0000003efc0100000002fb0000000800540069006d006501000000000000073f0000030000fffffffb0000000800540069006d006501000000000000045000000000000000000000048c0000039600000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000002ad0000035afc0200000012fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000001f2000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000280020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006700000002300000018e0000000000000000fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000000a0049006d00610067006501000002f4000000ca0000000000000000fb0000000a0049006d00610067006501000002f4000000ca0000000000000000fb0000000a0049006d006100670065000000013f000000660000000000000000fb0000000a0049006d0061006700650000000164000000940000000000000000fb0000000a0049006d00610067006500000001a3000000e80000000000000000fc00000227000001970000000000fffffffa000000000100000002fb0000000a0049006d0061006700650000000000ffffffff0000000000000000fb0000000a0049006d0061006700650000000000000002ad0000000000000000fb0000002000530070006f00740043006f006e00740072006f006c00500061006e0065006c0100000235000001620000016200ffffff000000010000010f00000396fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002800000396000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d0065010000000000000780000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004cd0000035a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
+    collapsed: false
+  SpotControlPanel:
     collapsed: false
   Time:
     collapsed: false
@@ -513,6 +358,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: true
-  Width: 1855
-  X: 65
-  Y: 24
+  Width: 1920
+  X: 0
+  Y: 27

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -1,0 +1,77 @@
+#ifndef SPOT_CONTROL_PANEL_H
+#define SPOT_CONTROL_PANEL_H
+
+#ifndef Q_MOC_RUN
+# include <ros/ros.h>
+
+# include <rviz/panel.h>
+#endif
+
+#include <QPushButton>
+#include <QLabel>
+#include <QDoubleSpinBox>
+
+namespace spot_viz
+{
+
+class ControlPanel : public rviz::Panel
+{
+    Q_OBJECT
+    public:
+    
+    ControlPanel(QWidget *parent=0);
+    virtual void save(rviz::Config config) const;
+    virtual void load(const rviz::Config &config);
+
+    private Q_SLOTS:
+    void sit();
+    void stand();
+    void claimLease();
+    void releaseLease();
+    void powerOn();
+    void powerOff();
+    void sendBodyPose();
+
+    private:
+
+    void toggleControlButtons();
+    void toggleBodyPoseButtons();
+    bool callTriggerService(ros::ServiceClient service, std::string serviceName);
+    void updateLabelTextWithLimit(QLabel* label, double limit);
+
+    ros::NodeHandle nh_;
+    ros::ServiceClient sitService_;
+    ros::ServiceClient standService_;
+    ros::ServiceClient claimLeaseService_;
+    ros::ServiceClient releaseLeaseService_;
+    ros::ServiceClient powerOnService_;
+    ros::ServiceClient powerOffService_;
+    ros::Publisher bodyPosePub_;
+
+    QPushButton* claimLeaseButton;
+    QPushButton* releaseLeaseButton;
+    QPushButton* powerOnButton;
+    QPushButton* powerOffButton;
+    QPushButton* setBodyPoseButton;
+    QPushButton* sitButton;
+    QPushButton* standButton;
+    QLabel* statusLabel;
+    QLabel* bodyHeightLabel;
+    QLabel* rollLabel;
+    QLabel* pitchLabel;
+    QLabel* yawLabel;
+    QDoubleSpinBox* linearXSpin;
+    QDoubleSpinBox* linearYSpin;
+    QDoubleSpinBox* angularZSpin;
+    QDoubleSpinBox* bodyHeightSpin;
+    QDoubleSpinBox* rollSpin;
+    QDoubleSpinBox* pitchSpin;
+    QDoubleSpinBox* yawSpin;
+
+    bool haveLease;
+
+};
+
+} // end namespace spot_viz
+
+#endif // SPOT_CONTROL_PANEL_H


### PR DESCRIPTION
Can use the panel to claim and release the lease, power on and off, sit down and stand up, and set the body pose.

To add, go to panels>add new panel and select SpotControlPanel in spot_viz

The panel looks as below and has been added to the view_robot rviz configuration.

![spot_rviz_ui](https://user-images.githubusercontent.com/636456/123096281-d60db380-d426-11eb-9287-d840edaeb9b5.png)

There is a status label on the bottom which shows the messages from the various services that are integrated when they are called.

The buttons are enabled when the UI claims the lease (it does not work if the lease is already claimed). They are disabled when the lease is released.

This makes it more convenient to access some of the driver's functionality, avoiding the need to use the commandline for simple commands.