### PR TITLE
Remove --inorder flag in description.launch

### DIFF
--- a/spot_description/launch/description.launch
+++ b/spot_description/launch/description.launch
@@ -1,5 +1,5 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro $(find spot_description)/urdf/spot.urdf.xacro --inorder" />
+  <param name="robot_description" command="$(find xacro)/xacro $(find spot_description)/urdf/spot.urdf.xacro" />
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 </launch>


### PR DESCRIPTION
With this flag under ROS Melodic, I receive a info message that `xacro: in-order processing became default in ROS Melodic. You can drop the option`. Since older ROS distributions are not supported, it could be dropped?

Also, when using the ROS extension in VS Code and wanting to debug a node that includes that launch file, it actually results in an error and the debug session is terminated.