### PR TITLE
Body pose actionserver, limit backwards velocity with limits, topic for trajectory commands

### DIFF
--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -12,6 +12,7 @@
   <exec_depend>spot_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -316,14 +316,13 @@ class SpotROS():
         except Exception as e:
             return SetLocomotionResponse(False, 'Error:{}'.format(e))
 
-    def handle_max_vel(self, req):
+    def handle_vel_limit(self, req):
         """
-        Handle a max_velocity service call. This will modify the mobility params to have a limit on the maximum
-        velocity that the robot can move during motion commmands. This affects trajectory commands and velocity
-        commands
+        Handle a velocity_limit service call. This will modify the mobility params to have a limit on velocity that
+        the robot can move during motion commmands. This affects trajectory commands and velocity commands
 
         Args:
-            req: SetVelocityRequest containing requested maximum velocity
+            req: SetVelocityRequest containing requested velocity limit
 
         Returns: SetVelocityResponse
         """
@@ -331,7 +330,10 @@ class SpotROS():
             mobility_params = self.spot_wrapper.get_mobility_params()
             mobility_params.vel_limit.CopyFrom(SE2VelocityLimit(max_vel=math_helpers.SE2Velocity(req.velocity_limit.linear.x,
                                                                                                  req.velocity_limit.linear.y,
-                                                                                                 req.velocity_limit.angular.z).to_proto()))
+                                                                                                 req.velocity_limit.angular.z).to_proto(),
+                                                                min_vel=math_helpers.SE2Velocity(-req.velocity_limit.linear.x,
+                                                                                                 -req.velocity_limit.linear.y,
+                                                                                                 -req.velocity_limit.angular.z).to_proto()))
             self.spot_wrapper.set_mobility_params(mobility_params)
             return SetVelocityResponse(True, 'Success')
         except Exception as e:
@@ -636,7 +638,7 @@ class SpotROS():
 
             rospy.Service("stair_mode", SetBool, self.handle_stair_mode)
             rospy.Service("locomotion_mode", SetLocomotion, self.handle_locomotion_mode)
-            rospy.Service("max_velocity", SetVelocity, self.handle_max_vel)
+            rospy.Service("velocity_limit", SetVelocity, self.handle_vel_limit)
             rospy.Service("clear_behavior_fault", ClearBehaviorFault, self.handle_clear_behavior_fault)
 
             rospy.Service("list_graph", ListGraph, self.handle_list_graph)

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -249,6 +249,13 @@ class SpotROS():
     def handle_stop(self, req):
         """ROS service handler for the stop service"""
         resp = self.spot_wrapper.stop()
+        message = "Spot stop service was called"
+        if self.navigate_as.is_active():
+            self.navigate_as.set_preempted(NavigateToResult(success=False, message=message))
+        if self.trajectory_server.is_active():
+            self.trajectory_server.set_preempted(TrajectoryResult(success=False, message=message))
+        if self.body_pose_as.is_active():
+            self.body_pose_as.set_preempted(PoseBodyResult(success=False, message=message))
         return TriggerResponse(resp[0], resp[1])
 
     def handle_self_right(self, req):

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -584,6 +584,8 @@ class SpotWrapper():
             precise_position: if set to false, the status STATUS_NEAR_GOAL and STATUS_AT_GOAL will be equivalent. If
             true, the robot must complete its final positioning before it will be considered to have successfully
             reached the goal.
+
+        Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message
         """
         self._at_goal = False
         self._near_goal = False

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -45,6 +45,7 @@ add_service_files(
 add_action_files(
   FILES
   NavigateTo.action
+  PoseBody.action
   Trajectory.action
 )
 

--- a/spot_msgs/action/PoseBody.action
+++ b/spot_msgs/action/PoseBody.action
@@ -3,9 +3,9 @@
 geometry_msgs/Pose body_pose
 
 # Alternative specification of the body pose with rpy (in degrees). These values are ignored if the body_pose is set
-uint8 roll
-uint8 pitch
-uint8 yaw
+int8 roll
+int8 pitch
+int8 yaw
 float32 body_height
 ---
 bool success

--- a/spot_msgs/action/PoseBody.action
+++ b/spot_msgs/action/PoseBody.action
@@ -1,0 +1,14 @@
+# The pose the body should be moved to. Only the orientation and the z component (body height) of position is considered.
+# If this is unset, the rpy/body height values will be used instead.
+geometry_msgs/Pose body_pose
+
+# Alternative specification of the body pose with rpy (in degrees). These values are ignored if the body_pose is set
+uint8 roll
+uint8 pitch
+uint8 yaw
+float32 body_height
+---
+bool success
+string message
+---
+string feedback

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -68,10 +68,10 @@
       </font>
      </property>
      <property name="toolTip">
-      <string>Soft stop, stops whatever the robot is doing</string>
+      <string>Gentle e-stop, stops whatever the robot is doing and then sits down</string>
      </property>
      <property name="text">
-      <string>Stop</string>
+      <string>Gentle E-stop</string>
      </property>
     </widget>
    </item>
@@ -81,7 +81,41 @@
       <string>Release the emergency stop</string>
      </property>
      <property name="text">
-      <string>Release Stop</string>
+      <string>Release E-stop</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QPushButton" name="stopButton">
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>300</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>25</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>Stop any action the robot is taking but do not sit down or kill motor power</string>
+     </property>
+     <property name="text">
+      <string>Stop Action</string>
      </property>
     </widget>
    </item>

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -192,7 +192,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>Set Max Velocity</string>
+            <string>Set Velocity Limit</string>
            </property>
           </widget>
          </item>

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -7,13 +7,84 @@
     <x>0</x>
     <y>0</y>
     <width>456</width>
-    <height>618</height>
+    <height>855</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QPushButton" name="hardStopButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>30</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>Hard emergency stop, kills power to motors</string>
+     </property>
+     <property name="text">
+      <string>Kill Motor Power</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QPushButton" name="gentleStopButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>300</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>30</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>Soft stop, stops whatever the robot is doing</string>
+     </property>
+     <property name="text">
+      <string>Stop</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="releaseStopButton">
+     <property name="toolTip">
+      <string>Release the emergency stop</string>
+     </property>
+     <property name="text">
+      <string>Release Stop</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -15,68 +15,68 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QPushButton" name="hardStopButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>30</pointsize>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>Hard emergency stop, kills power to motors</string>
-     </property>
-     <property name="text">
-      <string>Kill Motor Power</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QPushButton" name="gentleStopButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="baseSize">
-      <size>
-       <width>0</width>
-       <height>300</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>30</pointsize>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>Gentle e-stop, stops whatever the robot is doing and then sits down</string>
-     </property>
-     <property name="text">
-      <string>Gentle E-stop</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="hardStopButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>18</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>Hard emergency stop, kills power to motors</string>
+       </property>
+       <property name="text">
+        <string>Kill Motors</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="gentleStopButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="baseSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>18</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>Gentle e-stop, stops whatever the robot is doing and then sits down</string>
+       </property>
+       <property name="text">
+        <string>Gentle E-stop</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QPushButton" name="releaseStopButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="toolTip">
       <string>Release the emergency stop</string>
      </property>
@@ -86,29 +86,25 @@
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_4">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <widget class="QPushButton" name="stopButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="baseSize">
       <size>
        <width>0</width>
-       <height>300</height>
+       <height>0</height>
       </size>
      </property>
      <property name="font">
       <font>
-       <pointsize>25</pointsize>
+       <pointsize>15</pointsize>
       </font>
      </property>
      <property name="toolTip">

--- a/spot_viz/rviz/robot.rviz
+++ b/spot_viz/rviz/robot.rviz
@@ -313,7 +313,7 @@ Visualization Manager:
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetGoal
-      Topic: /move_base_simple/goal
+      Topic: /spot/go_to_pose
     - Class: rviz/PublishPoint
       Single click: true
       Topic: /clicked_point

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -42,6 +42,7 @@ namespace spot_viz
         hardStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/hard");
         gentleStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/gentle");
         releaseStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/release");
+        stopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/stop");
         bodyPosePub_ = nh_.advertise<geometry_msgs::Pose>("/spot/body_pose", 1);
 
         leaseSub_ = nh_.subscribe("/spot/status/leases", 1, &ControlPanel::leaseCallback, this);
@@ -56,9 +57,16 @@ namespace spot_viz
         setMaxVelButton = this->findChild<QPushButton*>("setMaxVelButton");
         statusLabel = this->findChild<QLabel*>("statusLabel");
 
-        gentleStopButton = this->findChild<QPushButton*>("gentleStopButton");
-        QPalette pal = gentleStopButton->palette();
+        stopButton = this->findChild<QPushButton*>("stopButton");
+        QPalette pal = stopButton->palette();
         pal.setColor(QPalette::Button, QColor(255, 165, 0));
+        stopButton->setAutoFillBackground(true);
+        stopButton->setPalette(pal);
+        stopButton->update();
+
+        gentleStopButton = this->findChild<QPushButton*>("gentleStopButton");
+        pal = gentleStopButton->palette();
+        pal.setColor(QPalette::Button, QColor(255, 0, 255));
         gentleStopButton->setAutoFillBackground(true);
         gentleStopButton->setPalette(pal);
         gentleStopButton->update();
@@ -136,6 +144,7 @@ namespace spot_viz
         connect(releaseStopButton, SIGNAL(clicked()), this, SLOT(releaseStop()));
         connect(hardStopButton, SIGNAL(clicked()), this, SLOT(hardStop()));
         connect(gentleStopButton, SIGNAL(clicked()), this, SLOT(gentleStop()));
+        connect(stopButton, SIGNAL(clicked()), this, SLOT(stop()));
         
     }
 
@@ -228,6 +237,10 @@ namespace spot_viz
     void ControlPanel::releaseLease() {
         if (callTriggerService(releaseLeaseService_, "release lease"))
             releaseLeaseButton->setEnabled(false);
+    }
+
+    void ControlPanel::stop() {
+        callTriggerService(stopService_, "stop");
     }
 
     void ControlPanel::hardStop() {

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -56,47 +56,47 @@ namespace spot_viz
         double linearVelocityLimit = 2;
         linearXSpin = this->findChild<QDoubleSpinBox*>("linearXSpin");
         linearXLabel = this->findChild<QLabel*>("linearXLabel");
-        updateLabelTextWithLimit(linearXLabel, linearVelocityLimit);
+        updateLabelTextWithLimit(linearXLabel, 0, linearVelocityLimit);
         linearXSpin->setMaximum(linearVelocityLimit);
-        linearXSpin->setMinimum(-linearVelocityLimit);
+        linearXSpin->setMinimum(0);
 
         linearYSpin = this->findChild<QDoubleSpinBox*>("linearYSpin");
         linearYLabel = this->findChild<QLabel*>("linearYLabel");
-        updateLabelTextWithLimit(linearYLabel, linearVelocityLimit);
+        updateLabelTextWithLimit(linearYLabel, 0, linearVelocityLimit);
         linearYSpin->setMaximum(linearVelocityLimit);
-        linearYSpin->setMinimum(-linearVelocityLimit);
+        linearYSpin->setMinimum(0);
 
         angularZSpin = this->findChild<QDoubleSpinBox*>("angularZSpin");
         angularZLabel = this->findChild<QLabel*>("angularZLabel");
-        updateLabelTextWithLimit(angularZLabel, linearVelocityLimit);
+        updateLabelTextWithLimit(angularZLabel, 0, linearVelocityLimit);
         angularZSpin->setMaximum(linearVelocityLimit);
-        angularZSpin->setMinimum(-linearVelocityLimit);
+        angularZSpin->setMinimum(0);
 
-        double bodyHeightLimit = 0.3;
+        double bodyHeightLimit = 0.15;
         bodyHeightSpin = this->findChild<QDoubleSpinBox*>("bodyHeightSpin");
         bodyHeightLabel = this->findChild<QLabel*>("bodyHeightLabel");
-        updateLabelTextWithLimit(bodyHeightLabel, bodyHeightLimit);
+        updateLabelTextWithLimit(bodyHeightLabel, -bodyHeightLimit, bodyHeightLimit);
         bodyHeightSpin->setMaximum(bodyHeightLimit);
         bodyHeightSpin->setMinimum(-bodyHeightLimit);
 
         double rollLimit = 20;
         rollSpin = this->findChild<QDoubleSpinBox*>("rollSpin");
         rollLabel = this->findChild<QLabel*>("rollLabel");
-        updateLabelTextWithLimit(rollLabel, rollLimit);
+        updateLabelTextWithLimit(rollLabel, -rollLimit, rollLimit);
         rollSpin->setMaximum(rollLimit);
         rollSpin->setMinimum(-rollLimit);
 
         double pitchLimit = 30;
         pitchSpin = this->findChild<QDoubleSpinBox*>("pitchSpin");
         pitchLabel = this->findChild<QLabel*>("pitchLabel");
-        updateLabelTextWithLimit(pitchLabel, pitchLimit);
+        updateLabelTextWithLimit(pitchLabel, -pitchLimit, pitchLimit);
         pitchSpin->setMaximum(pitchLimit);
         pitchSpin->setMinimum(-pitchLimit);
 
         double yawLimit = 30;
         yawSpin = this->findChild<QDoubleSpinBox*>("yawSpin");
         yawLabel = this->findChild<QLabel*>("yawLabel");
-        updateLabelTextWithLimit(yawLabel, yawLimit);
+        updateLabelTextWithLimit(yawLabel, -yawLimit, yawLimit);
         yawSpin->setMaximum(yawLimit);
         yawSpin->setMinimum(-yawLimit);
 
@@ -110,13 +110,14 @@ namespace spot_viz
         connect(setMaxVelButton, SIGNAL(clicked()), this, SLOT(setMaxVel()));
     }
 
-    void ControlPanel::updateLabelTextWithLimit(QLabel* label, double limit) {
+    void ControlPanel::updateLabelTextWithLimit(QLabel* label, double limit_lower, double limit_upper) {
         int precision = 1;
         // Kind of hacky but default to_string returns 6 digit precision which is unnecessary
-        std::string limit_value = std::to_string(limit).substr(0, std::to_string(limit).find(".") + precision + 1);
-        std::string limit_range = " [-" + limit_value + ", " + limit_value + "]";
+        std::string limit_lower_value = std::to_string(limit_lower).substr(0, std::to_string(limit_lower).find(".") + precision + 1);
+        std::string limit_upper_value = std::to_string(limit_upper).substr(0, std::to_string(limit_upper).find(".") + precision + 1);
+        std::string limit_range = " [" + limit_lower_value + ", " + limit_upper_value + "]";
         std::string current_text = label->text().toStdString();
-        label->setText(QString((current_text+ limit_range).c_str()));
+        label->setText(QString((current_text + limit_range).c_str()));
     }
 
     void ControlPanel::setControlButtons() {

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -39,6 +39,9 @@ namespace spot_viz
         powerOnService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/power_on");
         powerOffService_ = nh_.serviceClient<std_srvs::Trigger>("spot/power_off");
         maxVelocityService_ = nh_.serviceClient<spot_msgs::SetVelocity>("/spot/velocity_limit");
+        hardStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/hard");
+        gentleStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/gentle");
+        releaseStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/release");
         bodyPosePub_ = nh_.advertise<geometry_msgs::Pose>("/spot/body_pose", 1);
 
         leaseSub_ = nh_.subscribe("/spot/status/leases", 1, &ControlPanel::leaseCallback, this);
@@ -52,6 +55,28 @@ namespace spot_viz
         setBodyPoseButton = this->findChild<QPushButton*>("setBodyPoseButton");
         setMaxVelButton = this->findChild<QPushButton*>("setMaxVelButton");
         statusLabel = this->findChild<QLabel*>("statusLabel");
+
+        gentleStopButton = this->findChild<QPushButton*>("gentleStopButton");
+        QPalette pal = gentleStopButton->palette();
+        pal.setColor(QPalette::Button, QColor(255, 165, 0));
+        gentleStopButton->setAutoFillBackground(true);
+        gentleStopButton->setPalette(pal);
+        gentleStopButton->update();
+
+        hardStopButton = this->findChild<QPushButton*>("hardStopButton");
+        pal = hardStopButton->palette();
+        pal.setColor(QPalette::Button, QColor(255, 0, 0));
+        hardStopButton->setAutoFillBackground(true);
+        hardStopButton->setPalette(pal);
+        hardStopButton->update();
+
+        releaseStopButton = this->findChild<QPushButton*>("releaseStopButton");
+        pal = releaseStopButton->palette();
+        pal.setColor(QPalette::Button, QColor(0, 255, 0));
+        releaseStopButton->setAutoFillBackground(true);
+        releaseStopButton->setPalette(pal);
+        releaseStopButton->update();
+
 
         double linearVelocityLimit = 2;
         linearXSpin = this->findChild<QDoubleSpinBox*>("linearXSpin");
@@ -108,6 +133,10 @@ namespace spot_viz
         connect(standButton, SIGNAL(clicked()), this, SLOT(stand()));
         connect(setBodyPoseButton, SIGNAL(clicked()), this, SLOT(sendBodyPose()));
         connect(setMaxVelButton, SIGNAL(clicked()), this, SLOT(setMaxVel()));
+        connect(releaseStopButton, SIGNAL(clicked()), this, SLOT(releaseStop()));
+        connect(hardStopButton, SIGNAL(clicked()), this, SLOT(hardStop()));
+        connect(gentleStopButton, SIGNAL(clicked()), this, SLOT(gentleStop()));
+        
     }
 
     void ControlPanel::updateLabelTextWithLimit(QLabel* label, double limit_lower, double limit_upper) {
@@ -200,6 +229,18 @@ namespace spot_viz
         if (callTriggerService(releaseLeaseService_, "release lease"))
             releaseLeaseButton->setEnabled(false);
     }
+
+    void ControlPanel::hardStop() {
+        callTriggerService(hardStopService_, "hard stop");
+    }
+
+    void ControlPanel::gentleStop() {
+        callTriggerService(gentleStopService_, "gentle stop");
+    }
+
+    void ControlPanel::releaseStop() {
+        callTriggerService(releaseStopService_, "release stop");
+    }    
 
     void ControlPanel::setMaxVel() {
         spot_msgs::SetVelocity req;

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -38,7 +38,7 @@ namespace spot_viz
         releaseLeaseService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/release");
         powerOnService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/power_on");
         powerOffService_ = nh_.serviceClient<std_srvs::Trigger>("spot/power_off");
-        maxVelocityService_ = nh_.serviceClient<spot_msgs::SetVelocity>("/spot/max_velocity");
+        maxVelocityService_ = nh_.serviceClient<spot_msgs::SetVelocity>("/spot/velocity_limit");
         bodyPosePub_ = nh_.advertise<geometry_msgs::Pose>("/spot/body_pose", 1);
 
         leaseSub_ = nh_.subscribe("/spot/status/leases", 1, &ControlPanel::leaseCallback, this);
@@ -206,18 +206,18 @@ namespace spot_viz
         req.request.velocity_limit.linear.x = linearXSpin->value();
         req.request.velocity_limit.linear.y = linearYSpin->value();
 
-        std::string labelText = "Calling set max velocity service";
+        std::string labelText = "Calling set velocity limit service";
         statusLabel->setText(QString(labelText.c_str()));
         if (maxVelocityService_.call(req)) {
             if (req.response.success) {
-                labelText = "Successfully called set max velocity service";
+                labelText = "Successfully called set velocity limit service";
                 statusLabel->setText(QString(labelText.c_str()));
             } else {
-                labelText = "set max velocity service failed: " + req.response.message;
+                labelText = "set velocity limit service failed: " + req.response.message;
                 statusLabel->setText(QString(labelText.c_str()));
             }
         } else {
-            labelText = "Failed to call set max velocity service" + req.response.message;
+            labelText = "Failed to call set velocity limit service" + req.response.message;
             statusLabel->setText(QString(labelText.c_str()));
         }
     }

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -39,7 +39,7 @@ class ControlPanel : public rviz::Panel
     void setControlButtons();
     void toggleBodyPoseButtons();
     bool callTriggerService(ros::ServiceClient service, std::string serviceName);
-    void updateLabelTextWithLimit(QLabel* label, double limit);
+    void updateLabelTextWithLimit(QLabel* label, double limit, double limit_lower=0);
     void leaseCallback(const spot_msgs::LeaseArray::ConstPtr &leases);
 
     ros::NodeHandle nh_;

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -33,6 +33,9 @@ class ControlPanel : public rviz::Panel
     void powerOff();
     void sendBodyPose();
     void setMaxVel();
+    void gentleStop();
+    void hardStop();
+    void releaseStop();
 
     private:
 
@@ -50,6 +53,9 @@ class ControlPanel : public rviz::Panel
     ros::ServiceClient powerOnService_;
     ros::ServiceClient powerOffService_;
     ros::ServiceClient maxVelocityService_;
+    ros::ServiceClient hardStopService_;
+    ros::ServiceClient gentleStopService_;
+    ros::ServiceClient releaseStopService_;
     ros::Publisher bodyPosePub_;
     ros::Subscriber leaseSub_;
 
@@ -61,6 +67,9 @@ class ControlPanel : public rviz::Panel
     QPushButton* sitButton;
     QPushButton* standButton;
     QPushButton* setMaxVelButton;
+    QPushButton* hardStopButton;
+    QPushButton* gentleStopButton;
+    QPushButton* releaseStopButton;
     QLabel* linearXLabel;
     QLabel* linearYLabel;
     QLabel* angularZLabel;

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -39,7 +39,7 @@ class ControlPanel : public rviz::Panel
     void setControlButtons();
     void toggleBodyPoseButtons();
     bool callTriggerService(ros::ServiceClient service, std::string serviceName);
-    void updateLabelTextWithLimit(QLabel* label, double limit, double limit_lower=0);
+    void updateLabelTextWithLimit(QLabel* label, double limit_lower, double limit_upper);
     void leaseCallback(const spot_msgs::LeaseArray::ConstPtr &leases);
 
     ros::NodeHandle nh_;

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -11,6 +11,8 @@
 #include <QLabel>
 #include <QDoubleSpinBox>
 #include <spot_msgs/LeaseArray.h>
+#include <spot_msgs/EStopStateArray.h>
+
 
 namespace spot_viz
 {
@@ -45,6 +47,7 @@ class ControlPanel : public rviz::Panel
     bool callTriggerService(ros::ServiceClient service, std::string serviceName);
     void updateLabelTextWithLimit(QLabel* label, double limit_lower, double limit_upper);
     void leaseCallback(const spot_msgs::LeaseArray::ConstPtr &leases);
+    void estopCallback(const spot_msgs::EStopStateArray::ConstPtr &estops);
 
     ros::NodeHandle nh_;
     ros::ServiceClient sitService_;
@@ -60,6 +63,7 @@ class ControlPanel : public rviz::Panel
     ros::ServiceClient stopService_;
     ros::Publisher bodyPosePub_;
     ros::Subscriber leaseSub_;
+    ros::Subscriber estopSub_;
 
     QPushButton* claimLeaseButton;
     QPushButton* releaseLeaseButton;
@@ -90,6 +94,7 @@ class ControlPanel : public rviz::Panel
     QDoubleSpinBox* yawSpin;
 
     bool haveLease;
+    bool isEStopped;
 };
 
 } // end namespace spot_viz

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -36,6 +36,7 @@ class ControlPanel : public rviz::Panel
     void gentleStop();
     void hardStop();
     void releaseStop();
+    void stop();
 
     private:
 
@@ -56,6 +57,7 @@ class ControlPanel : public rviz::Panel
     ros::ServiceClient hardStopService_;
     ros::ServiceClient gentleStopService_;
     ros::ServiceClient releaseStopService_;
+    ros::ServiceClient stopService_;
     ros::Publisher bodyPosePub_;
     ros::Subscriber leaseSub_;
 
@@ -70,6 +72,7 @@ class ControlPanel : public rviz::Panel
     QPushButton* hardStopButton;
     QPushButton* gentleStopButton;
     QPushButton* releaseStopButton;
+    QPushButton* stopButton;
     QLabel* linearXLabel;
     QLabel* linearYLabel;
     QLabel* angularZLabel;


### PR DESCRIPTION
A few improvements to some of the motion commands

# Velocity limit

When I added this I called it max_velocity, and was only setting the max velocity. It turns out that the max velocity only means the motion in the forwards direction. When the `max_vel` was set, when the robot moved backwards it would move at whatever speed was the default. I don't think this is desirable behaviour. This PR also sets the `min_vel` to negative `max_vel`, which means that max velocity is consistent over forwards and backwards motion.

I have modified some of the display in the rviz panel to make it clearer what the velocity limits should be. I haven't actually checked the valid min/max range, so don't know if it will work. But a range of 0 to 2m/s seems sensible.

A note here which we may want to consider: I tested the cmd_vel command as part of these changes. It looks like the `synchro_velocity_command` does not take into account the max and min values that are set in the mobility params, although it does receive the mobility params. This means that if you are using cmd_vel to control the robot at any time, you should not expect whatever velocity limits you set to apply.

We might wish to manually limit the values that we receive in cmd_vel based on whatever the velocity limits are in mobility_params.

## Testing

To test, first verify without this PR that the forwards/backwards behaviour is not as expected. Start the robot and then start an action client

```
rosrun actionlib_tools axclient.py /spot/trajectory
```

And set the values to move forwards 1 metre

```yaml
target_pose: 
  header: 
    seq: 0
    stamp: 
      secs: 0
      nsecs:         0
    frame_id: 'body'
  pose: 
    position: 
      x: 1
      y: 0.0
      z: 0.0
    orientation: 
      x: 0.0
      y: 0.0
      z: 0.0
      w: 1
duration: 
  data: 
    secs: 5
    nsecs:         0
precise_positioning: False
```

You should see that the robot moves forwards at the default speed. Then set `x` to be -1, and the robot should move backwards at the same speed.

Now, adjust the velocity limits with the `/spot/max_vel` service:

```
rosservice call /spot/max_vel "velocity_limit:
  linear:
    x: 0.5
    y: 0.5
    z: 0.0
  angular:
    x: 0.0
    y: 0.0
    z: 0.5"
```

And repeat the forwards/backwards motion. You should see that the robot moves forwards at a reduced speed, but when going backwards moves at the default speed.

Now checkout this PR, and using the renamed service (or rviz) set the velocity limits:

```
rosservice call /spot/velocity_limit "velocity_limit:
  linear:
    x: 0.5
    y: 0.5
    z: 0.0
  angular:
    x: 0.0
    y: 0.0
    z: 0.5"
```

And then repeat the forwards/backwards motion. You should see that now the robot has the same velocity in both directions.

# Body pose actionserver

Currently the body pose can only be set by using a topic (or the rviz panel). I have added an actionserver to allow somewhat more convenient setting of the pose if you are not interacting through rviz. You can either set a pose, or set RPY + body height. If a pose is set, it will be used, and if no pose is set then RPY values will be used. RPY is provided in degrees because I think that is more convenient if you're doing things manually.

I also noticed that it appears that the body pose command that we are using does not allow the full range of body height adjustment. The limit is something around 0.15m, which approximately corresponds to the max height when using the controller slider. When using the controller in stand mode you can move the robot such that its legs are almost entirely straight and this is not possible with the current body pose command. I suspect that this is because we are setting the mobility params rather than using the stance command at https://dev.bostondynamics.com/python/bosdyn-client/src/bosdyn/client/robot_command#bosdyn.client.robot_command.RobotCommandBuilder.stance_command. Perhaps we should consider switching to using that instead. The mobility params are probably intended for specifying a pose which should be kept while walking.

I checked this and the behaviour seems to be that any height adjustment specified with the body pose is kept when a trajectory command is sent. Any roll or yaw that was applied is removed when the robot is in motion, but any pitch value set is retained. Once the robot is stationary again the yaw/roll values are reapplied.

https://user-images.githubusercontent.com/636456/132842905-6af78b41-0f68-403e-80a5-21678eacf5bf.mp4

## Testing

Start everything up and then start an action client

```
rosrun actionlib_tools axclient.py /spot/pose_body
```

Then specify a desired RPY + body height value. You can reset the body to neutral by sending an empty goal.

# Trajectory topic

We had a trajectory topic previously, but I then changed it to be an actionserver. I think this is slightly limiting and it can be useful to be able to control the robot using 2d nav goals from rviz. I have added a topic `/spot/go_to_pose` which interacts with the trajectory command as well. The default rviz config for the robot is set up to have the nav goal go to this topic.

Publishing to the topic will try to transform the pose received into the body frame, and do nothing if it cannot.

Since we are doing it for poses coming from rviz, I also made it so that you do not have to send poses to the actionserver in the body frame. It will use the same transform mechanism as the topic to transform the pose into the correct frame, and abort if it cannot.

## Testing

Run rviz with

```
roslaunch spot_viz view_robot.launch
```

Start everything up as normal, then use the 2d nav goal tool to specify a location for the robot to move to.

# Estop buttons in rviz

![Screenshot from 2021-09-15 17-09-50](https://user-images.githubusercontent.com/636456/133469758-4a1850d1-ef43-4553-8ef2-11ae2b6fad4b.png)
