### PR TITLE
Add hand images to the image topics

### DIFF
--- a/spot_driver/config/spot_ros.yaml
+++ b/spot_driver/config/spot_ros.yaml
@@ -5,6 +5,7 @@ rates:
   front_image: 10.0
   side_image: 10.0
   rear_image: 10.0
+  hand_image: 10.0
 auto_claim: False
 auto_power_on: False
 auto_stand: False

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -57,6 +57,7 @@ class SpotROS():
         self.callbacks["front_image"] = self.FrontImageCB
         self.callbacks["side_image"] = self.SideImageCB
         self.callbacks["rear_image"] = self.RearImageCB
+        self.callbacks["hand_image"] = self.HandImageCB
 
     def RobotStateCB(self, results):
         """Callback for when the Spot Wrapper gets new robot state data.
@@ -233,6 +234,29 @@ class SpotROS():
 
             self.populate_camera_static_transforms(data[0])
             self.populate_camera_static_transforms(data[1])
+
+    def HandImageCB(self, results):
+        """Callback for when the Spot Wrapper gets new hand image data.
+
+        Args:
+            results: FutureWrapper object of AsyncPeriodicQuery callback
+        """
+        data = self.spot_wrapper.hand_images
+        if data:
+            mage_msg0, camera_info_msg0 = getImageMsg(data[0], self.spot_wrapper)
+            self.hand_image_mono_pub.publish(mage_msg0)
+            self.hand_image_mono_info_pub.publish(camera_info_msg0)
+            mage_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper)
+            self.hand_depth_pub.publish(mage_msg1)
+            self.hand_depth_info_pub.publish(camera_info_msg1)
+            image_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper)
+            self.hand_image_color_pub.publish(image_msg2)
+            self.hand_image_color_info_pub.publish(camera_info_msg2)
+
+            self.populate_camera_static_transforms(data[0])
+            self.populate_camera_static_transforms(data[1])
+            self.populate_camera_static_transforms(data[2])
+
 
     def handle_claim(self, req):
         """ROS service handler for the claim service"""
@@ -528,26 +552,31 @@ class SpotROS():
             self.frontright_image_pub = rospy.Publisher('camera/frontright/image', Image, queue_size=10)
             self.left_image_pub = rospy.Publisher('camera/left/image', Image, queue_size=10)
             self.right_image_pub = rospy.Publisher('camera/right/image', Image, queue_size=10)
+            self.hand_image_mono_pub = rospy.Publisher('camera/hand_mono/image', Image, queue_size=10)
+            self.hand_image_color_pub = rospy.Publisher('camera/hand_color/image', Image, queue_size=10)
             # Depth #
             self.back_depth_pub = rospy.Publisher('depth/back/image', Image, queue_size=10)
             self.frontleft_depth_pub = rospy.Publisher('depth/frontleft/image', Image, queue_size=10)
             self.frontright_depth_pub = rospy.Publisher('depth/frontright/image', Image, queue_size=10)
             self.left_depth_pub = rospy.Publisher('depth/left/image', Image, queue_size=10)
             self.right_depth_pub = rospy.Publisher('depth/right/image', Image, queue_size=10)
-
+            self.hand_depth_pub = rospy.Publisher('depth/hand/image', Image, queue_size=10)
             # Image Camera Info #
             self.back_image_info_pub = rospy.Publisher('camera/back/camera_info', CameraInfo, queue_size=10)
             self.frontleft_image_info_pub = rospy.Publisher('camera/frontleft/camera_info', CameraInfo, queue_size=10)
             self.frontright_image_info_pub = rospy.Publisher('camera/frontright/camera_info', CameraInfo, queue_size=10)
             self.left_image_info_pub = rospy.Publisher('camera/left/camera_info', CameraInfo, queue_size=10)
             self.right_image_info_pub = rospy.Publisher('camera/right/camera_info', CameraInfo, queue_size=10)
+            self.hand_image_mono_info_pub = rospy.Publisher('camera/hand_mono/camera_info', CameraInfo, queue_size=10)
+            self.hand_image_color_info_pub = rospy.Publisher('camera/hand_color/camera_info', CameraInfo, queue_size=10)
+            
             # Depth Camera Info #
             self.back_depth_info_pub = rospy.Publisher('depth/back/camera_info', CameraInfo, queue_size=10)
             self.frontleft_depth_info_pub = rospy.Publisher('depth/frontleft/camera_info', CameraInfo, queue_size=10)
             self.frontright_depth_info_pub = rospy.Publisher('depth/frontright/camera_info', CameraInfo, queue_size=10)
             self.left_depth_info_pub = rospy.Publisher('depth/left/camera_info', CameraInfo, queue_size=10)
             self.right_depth_info_pub = rospy.Publisher('depth/right/camera_info', CameraInfo, queue_size=10)
-
+            self.hand_depth_info_pub = rospy.Publisher('depth/hand/camera_info', CameraInfo, queue_size=10)
             # Status Publishers #
             self.joint_state_pub = rospy.Publisher('joint_states', JointState, queue_size=10)
             """Defining a TF publisher manually because of conflicts between Python3 and tf"""

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -34,6 +34,8 @@ side_image_sources = ['left_fisheye_image', 'right_fisheye_image', 'left_depth',
 """List of image sources for side image periodic query"""
 rear_image_sources = ['back_fisheye_image', 'back_depth']
 """List of image sources for rear image periodic query"""
+hand_image_sources = ['hand_image', 'hand_depth', 'hand_color_image']
+"""List of image sources for hand image periodic query"""
 
 class AsyncRobotState(AsyncPeriodicQuery):
     """Class to get robot state at regular intervals.  get_robot_state_async query sent to the robot at every tick.  Callback registered to defined callback function.
@@ -240,6 +242,10 @@ class SpotWrapper():
         for source in rear_image_sources:
             self._rear_image_requests.append(build_image_request(source, image_format=image_pb2.Image.FORMAT_RAW))
 
+        self._hand_image_requests = []
+        for source in hand_image_sources:
+            self._hand_image_requests.append(build_image_request(source, image_format=image_pb2.Image.FORMAT_RAW))
+
         try:
             self._sdk = create_standard_sdk('ros_spot')
         except Exception as e:
@@ -288,12 +294,13 @@ class SpotWrapper():
             self._front_image_task = AsyncImageService(self._image_client, self._logger, max(0.0, self._rates.get("front_image", 0.0)), self._callbacks.get("front_image", lambda:None), self._front_image_requests)
             self._side_image_task = AsyncImageService(self._image_client, self._logger, max(0.0, self._rates.get("side_image", 0.0)), self._callbacks.get("side_image", lambda:None), self._side_image_requests)
             self._rear_image_task = AsyncImageService(self._image_client, self._logger, max(0.0, self._rates.get("rear_image", 0.0)), self._callbacks.get("rear_image", lambda:None), self._rear_image_requests)
+            self._hand_image_task = AsyncImageService(self._image_client, self._logger, max(0.0, self._rates.get("hand_image", 0.0)), self._callbacks.get("hand_image", lambda:None), self._hand_image_requests)
             self._idle_task = AsyncIdle(self._robot_command_client, self._logger, 10.0, self)
 
             self._estop_endpoint = None
 
             self._async_tasks = AsyncTasks(
-                [self._robot_state_task, self._robot_metrics_task, self._lease_task, self._front_image_task, self._side_image_task, self._rear_image_task, self._idle_task])
+                [self._robot_state_task, self._robot_metrics_task, self._lease_task, self._front_image_task, self._side_image_task, self._rear_image_task, self._hand_image_task, self._idle_task])
 
             self._robot_id = None
             self._lease = None
@@ -342,6 +349,11 @@ class SpotWrapper():
     def rear_images(self):
         """Return latest proto from the _rear_image_task"""
         return self._rear_image_task.proto
+
+    @property
+    def hand_images(self):
+        """Return latest proto from the _hand_image_task"""
+        return self._hand_image_task.proto
 
     @property
     def is_standing(self):

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -16,11 +16,17 @@ from bosdyn.api import image_pb2
 from bosdyn.api.graph_nav import graph_nav_pb2
 from bosdyn.api.graph_nav import map_pb2
 from bosdyn.api.graph_nav import nav_pb2
+from bosdyn.api import trajectory_pb2
+from bosdyn.api import arm_command_pb2
+from bosdyn.api import synchronized_command_pb2
+from bosdyn.api import robot_command_pb2
 from bosdyn.client.estop import EstopClient, EstopEndpoint, EstopKeepAlive
 from bosdyn.client import power
 from bosdyn.client import frame_helpers
 from bosdyn.client import math_helpers
 from bosdyn.client.exceptions import InternalServerError
+
+from bosdyn.util import seconds_to_duration
 
 from . import graph_nav_util
 
@@ -201,6 +207,21 @@ class AsyncIdle(AsyncPeriodicQuery):
                 self._logger.error("Error when getting robot command feedback: %s", e)
                 self._spot_wrapper._last_trajectory_command = None
 
+        if self._spot_wrapper._last_arm_trajectory_command != None:
+            try:
+                feedback_resp = self._client.robot_command_feedback(self._spot_wrapper._last_arm_trajectory_command)
+                status = feedback_resp.feedback.synchronized_feedback.arm_command_feedback.arm_cartesian_feedback.status
+                if status == arm_command_pb2.ArmCartesianCommand.Feedback.STATUS_TRAJECTORY_COMPLETE:
+                    # reached the goal
+                    self._spot_wrapper._arm_at_goal = True
+                    self._spot_wrapper._last_arm_trajectory_command = None
+                else:
+                    self._spot_wrapper.last_arm_trajectory_command = None
+            except (ResponseError, RpcError) as e:
+                self._logger.error("Error when getting robot command feedback: %s", e)
+                self._spot_wrapper._last_arm_trajectory_command = None
+
+
         self._spot_wrapper._is_moving = is_moving
 
         if self._spot_wrapper.is_standing and not self._spot_wrapper.is_moving:
@@ -229,6 +250,10 @@ class SpotWrapper():
         self._last_trajectory_command = None
         self._last_trajectory_command_precise = None
         self._last_velocity_command_time = None
+
+        self._arm_at_goal = False
+        self._last_arm_trajectory_command = None
+
 
         self._front_image_requests = []
         for source in front_image_sources:
@@ -377,6 +402,10 @@ class SpotWrapper():
     @property
     def at_goal(self):
         return self._at_goal
+
+    @property
+    def arm_at_goal(self):
+        return self._arm_at_goal
 
     @property
     def time_skew(self):
@@ -635,6 +664,49 @@ class SpotWrapper():
         if response[0]:
             self._last_trajectory_command = response[2]
         return response[0], response[1]
+
+    def arm_trajectory_cmd(self, position, orientation, cmd_duration, frame_name='odom'):
+        self._arm_at_goal = False
+        self._logger.info("got command duration of {}".format(cmd_duration))
+        end_time = time.time() + cmd_duration
+        if frame_name == 'vision':
+            rotation = math_helpers.Quat(orientation.w, orientation.x, orientation.y, orientation.z)
+
+            t = cmd_duration
+
+            hand_pose = math_helpers.SE3Pose(x=position.x, y=position.y, z=position.z, rot=rotation)
+
+            traj_point = trajectory_pb2.SE3TrajectoryPoint(
+                pose=hand_pose.to_proto(), time_since_reference=seconds_to_duration(t))
+            
+            hand_traj = trajectory_pb2.SE3Trajectory(points=[traj_point])
+
+            arm_cartesian_command = arm_command_pb2.ArmCartesianCommand.Request(
+                pose_trajectory_in_task=hand_traj, root_frame_name=frame_helpers.BODY_FRAME_NAME)
+
+            arm_command = arm_command_pb2.ArmCommand.Request(
+                arm_cartesian_command=arm_cartesian_command)
+
+            synchronized_command = synchronized_command_pb2.SynchronizedCommand.Request(
+                arm_command=arm_command)
+            
+            robot_command = robot_command_pb2.RobotCommand(
+                synchronized_command=synchronized_command)
+
+            # keep gripper open during the command
+            robot_command = RobotCommandBuilder.claw_gripper_open_fraction_command(
+                1, build_on_command=robot_command)
+            
+            self._logger.info("Sending trajectory command...")
+
+            success, success_str, id = self._robot_command(robot_command, end_time_secs=end_time)
+
+            if success:
+                self._last_arm_trajectory_command = id
+            return success, success_str
+
+        else:
+            raise ValueError("frame_name must be vision")
 
     def list_graph(self, upload_path):
         """List waypoint ids of garph_nav


### PR DESCRIPTION
This PR fetches the hand images from the spot python client and publishes them as Image topics. 
These three sources are currently published:

- hand_image
- hand_color_image
- hand_depth

These two are currently not publishes, but could be added. I wasn't sure if they are important enough, since I did not need them.

- hand_color_in_hand_depth_frame
- hand_depth_in_hand_color_frame

These five sources are all the sources returned by this code
```
image_client = robot.ensure_client(ImageClient.default_service_name)
image_sources = image_client.list_image_sources()
```