### PR TITLE
Add service for dock and undock

### DIFF
--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -35,6 +35,7 @@ from spot_msgs.srv import ListGraph, ListGraphResponse
 from spot_msgs.srv import SetLocomotion, SetLocomotionResponse
 from spot_msgs.srv import ClearBehaviorFault, ClearBehaviorFaultResponse
 from spot_msgs.srv import SetVelocity, SetVelocityResponse
+from spot_msgs.srv import Dock, DockResponse
 
 from .ros_helpers import *
 from .spot_wrapper import SpotWrapper
@@ -396,6 +397,16 @@ class SpotROS():
                 self.trajectory_server.publish_feedback(TrajectoryFeedback("Failed to reach goal"))
                 self.trajectory_server.set_aborted(TrajectoryResult(False, "Failed to reach goal"))
 
+    def handle_dock(self, req):
+        """Dock the robot"""
+        resp = self.spot_wrapper.dock(req.dock_id)
+        return DockResponse(resp[0], resp[1])
+
+    def handle_undock(self, req):
+        """Undock the robot"""
+        resp = self.spot_wrapper.undock()
+        return TriggerResponse(resp[0], resp[1])
+
     def cmdVelCallback(self, data):
         """Callback for cmd_vel command"""
         self.spot_wrapper.velocity_cmd(data.linear.x, data.linear.y, data.angular.z)
@@ -591,6 +602,10 @@ class SpotROS():
             rospy.Service("clear_behavior_fault", ClearBehaviorFault, self.handle_clear_behavior_fault)
 
             rospy.Service("list_graph", ListGraph, self.handle_list_graph)
+
+            # Docking
+            rospy.Service("dock", Dock, self.handle_dock)
+            rospy.Service("undock", Trigger, self.handle_undock)
 
             self.navigate_as = actionlib.SimpleActionServer('navigate_to', NavigateToAction,
                                                             execute_cb = self.handle_navigate_to,

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -40,6 +40,7 @@ add_service_files(
   SetLocomotion.srv
   SetVelocity.srv
   ClearBehaviorFault.srv
+  Dock.srv
 )
 
 add_action_files(

--- a/spot_msgs/srv/Dock.srv
+++ b/spot_msgs/srv/Dock.srv
@@ -1,0 +1,4 @@
+uint32 dock_id # dock fiducials id
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages


### PR DESCRIPTION
This PR supports Spot Dock.
It enables Spot to dock and undock via rosservice.

- Usage
```
$ rosservice call /spot/dock "dock_id: '[dock fiducial id]'"
$ rosservice call /spot/undock "{}"
```

Cc: @k-okada @sktometometo @mqcmd196
