### PR TITLE
Allow access to more of the SDK, improve rviz displays, safety improvements

### DIFF
--- a/spot_driver/launch/driver.launch
+++ b/spot_driver/launch/driver.launch
@@ -2,6 +2,7 @@
   <arg name="username" default="dummyusername" />
   <arg name="password" default="dummypassword" />
   <arg name="hostname" default="192.168.50.3" />
+  <arg name="estop_timeout" default="9.0"/>
 
   <include file="$(find spot_description)/launch/description.launch" />
   <include file="$(find spot_driver)/launch/control.launch" />
@@ -12,6 +13,7 @@
     <param name="username" value="$(arg username)" />
     <param name="password" value="$(arg password)" />
     <param name="hostname" value="$(arg hostname)" />
+    <param name="estop_timeout" value="$(arg estop_timeout)"/>
     <remap from="joint_states" to="/joint_states"/>
     <remap from="tf" to="/tf"/>
   </node>

--- a/spot_driver/launch/driver.launch
+++ b/spot_driver/launch/driver.launch
@@ -4,6 +4,11 @@
   <arg name="hostname" default="192.168.50.3" />
   <arg name="estop_timeout" default="9.0"/>
   <arg name="autonomy_enabled" default="true"/>
+  <arg name="estop_timeout" default="9.0"/>
+  <!-- In m/s. 0 applies spot's internal limits -->
+  <arg name="max_linear_velocity_x" default="0"/>
+  <arg name="max_linear_velocity_y" default="0"/>
+  <arg name="max_angular_velocity_z" default="0"/>
 
   <include file="$(find spot_description)/launch/description.launch" />
   <include file="$(find spot_driver)/launch/control.launch" />
@@ -16,6 +21,10 @@
     <param name="hostname" value="$(arg hostname)" />
     <param name="estop_timeout" value="$(arg estop_timeout)"/>
     <param name="autonomy_enabled" value="$(arg autonomy_enabled)"/>
+    <param name="estop_timeout" value="$(arg estop_timeout)"/>
+    <param name="max_linear_velocity_x" value="$(arg max_linear_velocity_x)"/>
+    <param name="max_linear_velocity_y" value="$(arg max_linear_velocity_y)"/>
+    <param name="max_angular_velocity_z" value="$(arg max_angular_velocity_z)"/>
     <remap from="joint_states" to="/joint_states"/>
     <remap from="tf" to="/tf"/>
   </node>

--- a/spot_driver/launch/driver.launch
+++ b/spot_driver/launch/driver.launch
@@ -9,6 +9,7 @@
   <arg name="max_linear_velocity_x" default="0"/>
   <arg name="max_linear_velocity_y" default="0"/>
   <arg name="max_angular_velocity_z" default="0"/>
+  <arg name="allow_motion" default="true"/>
 
   <include file="$(find spot_description)/launch/description.launch" />
   <include file="$(find spot_driver)/launch/control.launch" />
@@ -25,6 +26,7 @@
     <param name="max_linear_velocity_x" value="$(arg max_linear_velocity_x)"/>
     <param name="max_linear_velocity_y" value="$(arg max_linear_velocity_y)"/>
     <param name="max_angular_velocity_z" value="$(arg max_angular_velocity_z)"/>
+    <param name="allow_motion" value="$(arg allow_motion)"/>
     <remap from="joint_states" to="/joint_states"/>
     <remap from="tf" to="/tf"/>
   </node>

--- a/spot_driver/launch/driver.launch
+++ b/spot_driver/launch/driver.launch
@@ -3,6 +3,7 @@
   <arg name="password" default="dummypassword" />
   <arg name="hostname" default="192.168.50.3" />
   <arg name="estop_timeout" default="9.0"/>
+  <arg name="autonomy_enabled" default="true"/>
 
   <include file="$(find spot_description)/launch/description.launch" />
   <include file="$(find spot_driver)/launch/control.launch" />
@@ -14,6 +15,7 @@
     <param name="password" value="$(arg password)" />
     <param name="hostname" value="$(arg hostname)" />
     <param name="estop_timeout" value="$(arg estop_timeout)"/>
+    <param name="autonomy_enabled" value="$(arg autonomy_enabled)"/>
     <remap from="joint_states" to="/joint_states"/>
     <remap from="tf" to="/tf"/>
   </node>

--- a/spot_driver/launch/driver.launch
+++ b/spot_driver/launch/driver.launch
@@ -4,7 +4,6 @@
   <arg name="hostname" default="192.168.50.3" />
   <arg name="estop_timeout" default="9.0"/>
   <arg name="autonomy_enabled" default="true"/>
-  <arg name="estop_timeout" default="9.0"/>
   <!-- In m/s. 0 applies spot's internal limits -->
   <arg name="max_linear_velocity_x" default="0"/>
   <arg name="max_linear_velocity_y" default="0"/>

--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -12,6 +12,7 @@
   <exec_depend>spot_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -270,16 +270,24 @@ class SpotROS():
 
     def handle_self_right(self, req):
         """ROS service handler for the self-right service"""
+        if not self.robot_allowed_to_move():
+            return TriggerResponse(False, "Robot motion is not allowed")
+
         resp = self.spot_wrapper.self_right()
         return TriggerResponse(resp[0], resp[1])
 
     def handle_sit(self, req):
         """ROS service handler for the sit service"""
+        if not self.robot_allowed_to_move():
+            return TriggerResponse(False, "Robot motion is not allowed")
+
         resp = self.spot_wrapper.sit()
         return TriggerResponse(resp[0], resp[1])
 
     def handle_stand(self, req):
         """ROS service handler for the stand service"""
+        if not self.robot_allowed_to_move():
+            return TriggerResponse(False, "Robot motion is not allowed")
         resp = self.spot_wrapper.stand()
         return TriggerResponse(resp[0], resp[1])
 
@@ -450,6 +458,7 @@ class SpotROS():
 
         """
         self.allow_motion = req.data
+        rospy.loginfo("Robot motion is now {}", "allowed" if self.allow_motion else "disallowed")
         if not self.allow_motion:
             # Always send a stop command if disallowing motion, in case the robot is moving when it is sent
             self.spot_wrapper.stop()

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -316,14 +316,13 @@ class SpotROS():
         except Exception as e:
             return SetLocomotionResponse(False, 'Error:{}'.format(e))
 
-    def handle_max_vel(self, req):
+    def handle_vel_limit(self, req):
         """
-        Handle a max_velocity service call. This will modify the mobility params to have a limit on the maximum
-        velocity that the robot can move during motion commmands. This affects trajectory commands and velocity
-        commands
+        Handle a velocity_limit service call. This will modify the mobility params to have a limit on velocity that
+        the robot can move during motion commmands. This affects trajectory commands and velocity commands
 
         Args:
-            req: SetVelocityRequest containing requested maximum velocity
+            req: SetVelocityRequest containing requested velocity limit
 
         Returns: SetVelocityResponse
         """
@@ -331,7 +330,10 @@ class SpotROS():
             mobility_params = self.spot_wrapper.get_mobility_params()
             mobility_params.vel_limit.CopyFrom(SE2VelocityLimit(max_vel=math_helpers.SE2Velocity(req.velocity_limit.linear.x,
                                                                                                  req.velocity_limit.linear.y,
-                                                                                                 req.velocity_limit.angular.z).to_proto()))
+                                                                                                 req.velocity_limit.angular.z).to_proto(),
+                                                                min_vel=math_helpers.SE2Velocity(-req.velocity_limit.linear.x,
+                                                                                                 -req.velocity_limit.linear.y,
+                                                                                                 -req.velocity_limit.angular.z).to_proto()))
             self.spot_wrapper.set_mobility_params(mobility_params)
             return SetVelocityResponse(True, 'Success')
         except Exception as e:
@@ -636,7 +638,7 @@ class SpotROS():
 
             rospy.Service("stair_mode", SetBool, self.handle_stair_mode)
             rospy.Service("locomotion_mode", SetLocomotion, self.handle_locomotion_mode)
-            rospy.Service("max_velocity", SetVelocity, self.handle_max_vel)
+            rospy.Service("velocity_limit", SetVelocity, self.handle_vel_limit)
             rospy.Service("clear_behavior_fault", ClearBehaviorFault, self.handle_clear_behavior_fault)
 
             rospy.Service("list_graph", ListGraph, self.handle_list_graph)

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -735,7 +735,6 @@ class SpotROS():
 
             rospy.Service("claim", Trigger, self.handle_claim)
             rospy.Service("release", Trigger, self.handle_release)
-            rospy.Service("stop", Trigger, self.handle_stop)
             rospy.Service("self_right", Trigger, self.handle_self_right)
             rospy.Service("sit", Trigger, self.handle_sit)
             rospy.Service("stand", Trigger, self.handle_stand)
@@ -767,6 +766,10 @@ class SpotROS():
                                                              execute_cb=self.handle_body_pose,
                                                              auto_start=False)
             self.body_pose_as.start()
+
+            # Stop service calls other services so initialise it after them to prevent crashes which can happen if
+            # the service is immediately called
+            rospy.Service("stop", Trigger, self.handle_stop)
 
             rospy.on_shutdown(self.shutdown)
 

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -464,7 +464,7 @@ class SpotROS():
 
         """
         self.allow_motion = req.data
-        rospy.loginfo("Robot motion is now {}", "allowed" if self.allow_motion else "disallowed")
+        rospy.loginfo("Robot motion is now {}".format("allowed" if self.allow_motion else "disallowed"))
         if not self.allow_motion:
             # Always send a stop command if disallowing motion, in case the robot is moving when it is sent
             self.spot_wrapper.stop()

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -249,6 +249,13 @@ class SpotROS():
     def handle_stop(self, req):
         """ROS service handler for the stop service"""
         resp = self.spot_wrapper.stop()
+        message = "Spot stop service was called"
+        if self.navigate_as.is_active():
+            self.navigate_as.set_preempted(NavigateToResult(success=False, message=message))
+        if self.trajectory_server.is_active():
+            self.trajectory_server.set_preempted(TrajectoryResult(success=False, message=message))
+        if self.body_pose_as.is_active():
+            self.body_pose_as.set_preempted(PoseBodyResult(success=False, message=message))
         return TriggerResponse(resp[0], resp[1])
 
     def handle_self_right(self, req):

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -632,6 +632,7 @@ class SpotROS():
         self.password = rospy.get_param('~password', 'default_value')
         self.hostname = rospy.get_param('~hostname', 'default_value')
         self.motion_deadzone = rospy.get_param('~deadzone', 0.05)
+        self.estop_timeout = rospy.get_param('~estop_timeout', 9.0)
 
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
@@ -658,7 +659,7 @@ class SpotROS():
         self.logger = logging.getLogger('rosout')
 
         rospy.loginfo("Starting ROS driver for Spot")
-        self.spot_wrapper = SpotWrapper(self.username, self.password, self.hostname, self.logger, self.rates, self.callbacks)
+        self.spot_wrapper = SpotWrapper(self.username, self.password, self.hostname, self.logger, self.estop_timeout, self.rates, self.callbacks)
 
         if self.spot_wrapper.is_valid:
             # Images #

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -353,6 +353,9 @@ class SpotROS():
         Returns: (bool, str) boolean indicating whether the call was successful, along with a message
 
         """
+        if any(map(lambda x: 0 < x < 0.15, [max_linear_x, max_linear_y, max_angular_z])):
+            return False, 'Error: One of the values provided to velocity limits was below 0.15. Values in the range (' \
+                          '0,0.15) can cause unexpected behaviour of the trajectory command.'
         try:
             mobility_params = self.spot_wrapper.get_mobility_params()
             mobility_params.vel_limit.CopyFrom(SE2VelocityLimit(max_vel=math_helpers.SE2Velocity(max_linear_x,

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -193,7 +193,11 @@ class AsyncIdle(AsyncPeriodicQuery):
                 elif status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_NEAR_GOAL:
                     is_moving = True
                     self._spot_wrapper._near_goal = True
+                elif status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_UNKNOWN:
+                    self._spot_wrapper._trajectory_status_unknown = True
+                    self._spot_wrapper._last_trajectory_command = None
                 else:
+                    self._logger.error("Received trajectory command status outside of expected range, value is {}".format(status))
                     self._spot_wrapper._last_trajectory_command = None
             except (ResponseError, RpcError) as e:
                 self._logger.error("Error when getting robot command feedback: %s", e)
@@ -222,6 +226,7 @@ class SpotWrapper():
         self._is_moving = False
         self._at_goal = False
         self._near_goal = False
+        self._trajectory_status_unknown = False
         self._last_stand_command = None
         self._last_sit_command = None
         self._last_trajectory_command = None
@@ -589,6 +594,7 @@ class SpotWrapper():
         """
         self._at_goal = False
         self._near_goal = False
+        self._trajectory_status_unknown = False
         self._last_trajectory_command_precise = precise_position
         self._logger.info("got command duration of {}".format(cmd_duration))
         end_time=time.time() + cmd_duration

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -210,13 +210,14 @@ class AsyncIdle(AsyncPeriodicQuery):
 
 class SpotWrapper():
     """Generic wrapper class to encompass release 1.1.4 API features as well as maintaining leases automatically"""
-    def __init__(self, username, password, hostname, logger, rates = {}, callbacks = {}):
+    def __init__(self, username, password, hostname, logger, estop_timeout=9.0, rates = {}, callbacks = {}):
         self._username = username
         self._password = password
         self._hostname = hostname
         self._logger = logger
         self._rates = rates
         self._callbacks = callbacks
+        self._estop_timeout = estop_timeout
         self._keep_alive = True
         self._valid = True
 
@@ -427,7 +428,7 @@ class SpotWrapper():
 
     def resetEStop(self):
         """Get keepalive for eStop"""
-        self._estop_endpoint = EstopEndpoint(self._estop_client, 'ros', 9.0)
+        self._estop_endpoint = EstopEndpoint(self._estop_client, 'ros', self._estop_timeout)
         self._estop_endpoint.force_simple_setup()  # Set this endpoint as the robot's sole estop.
         self._estop_keepalive = EstopKeepAlive(self._estop_endpoint)
 

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -584,6 +584,8 @@ class SpotWrapper():
             precise_position: if set to false, the status STATUS_NEAR_GOAL and STATUS_AT_GOAL will be equivalent. If
             true, the robot must complete its final positioning before it will be considered to have successfully
             reached the goal.
+
+        Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message
         """
         self._at_goal = False
         self._near_goal = False

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -45,6 +45,7 @@ add_service_files(
 add_action_files(
   FILES
   NavigateTo.action
+  PoseBody.action
   Trajectory.action
 )
 

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -38,6 +38,7 @@ add_service_files(
   FILES
   ListGraph.srv
   SetLocomotion.srv
+  SetSwingHeight.srv
   SetVelocity.srv
   ClearBehaviorFault.srv
 )

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -32,6 +32,8 @@ add_message_files(
   LeaseResource.msg
   PowerState.msg
   SystemFaultState.msg
+  ObstacleParams.msg
+  TerrainParams.msg
 )
 
 add_service_files(
@@ -41,6 +43,8 @@ add_service_files(
   SetSwingHeight.srv
   SetVelocity.srv
   ClearBehaviorFault.srv
+  SetObstacleParams.srv
+  SetTerrainParams.srv
 )
 
 add_action_files(

--- a/spot_msgs/action/PoseBody.action
+++ b/spot_msgs/action/PoseBody.action
@@ -3,9 +3,9 @@
 geometry_msgs/Pose body_pose
 
 # Alternative specification of the body pose with rpy (in degrees). These values are ignored if the body_pose is set
-uint8 roll
-uint8 pitch
-uint8 yaw
+int8 roll
+int8 pitch
+int8 yaw
 float32 body_height
 ---
 bool success

--- a/spot_msgs/action/PoseBody.action
+++ b/spot_msgs/action/PoseBody.action
@@ -1,0 +1,14 @@
+# The pose the body should be moved to. Only the orientation and the z component (body height) of position is considered.
+# If this is unset, the rpy/body height values will be used instead.
+geometry_msgs/Pose body_pose
+
+# Alternative specification of the body pose with rpy (in degrees). These values are ignored if the body_pose is set
+uint8 roll
+uint8 pitch
+uint8 yaw
+float32 body_height
+---
+bool success
+string message
+---
+string feedback

--- a/spot_msgs/msg/MobilityParams.msg
+++ b/spot_msgs/msg/MobilityParams.msg
@@ -3,3 +3,5 @@ uint32 locomotion_hint
 uint8 swing_height
 bool stair_hint
 geometry_msgs/Twist velocity_limit
+spot_msgs/ObstacleParams obstacle_params
+spot_msgs/TerrainParams terrain_params

--- a/spot_msgs/msg/MobilityParams.msg
+++ b/spot_msgs/msg/MobilityParams.msg
@@ -1,3 +1,4 @@
 geometry_msgs/Pose body_control
 uint32 locomotion_hint
 bool stair_hint
+geometry_msgs/Twist velocity_limit

--- a/spot_msgs/msg/MobilityParams.msg
+++ b/spot_msgs/msg/MobilityParams.msg
@@ -1,4 +1,5 @@
 geometry_msgs/Pose body_control
 uint32 locomotion_hint
+uint8 swing_height
 bool stair_hint
 geometry_msgs/Twist velocity_limit

--- a/spot_msgs/msg/ObstacleParams.msg
+++ b/spot_msgs/msg/ObstacleParams.msg
@@ -1,0 +1,7 @@
+# see https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference.html?highlight=power_state#obstacleparams
+bool disable_vision_foot_obstacle_avoidance
+bool disable_vision_foot_constraint_avoidance
+bool disable_vision_body_obstacle_avoidance
+float32 obstacle_avoidance_padding
+bool disable_vision_foot_obstacle_body_assist
+bool disable_vision_negative_obstacles

--- a/spot_msgs/msg/TerrainParams.msg
+++ b/spot_msgs/msg/TerrainParams.msg
@@ -1,0 +1,8 @@
+# see https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference.html?highlight=power_state#terrainparams
+uint8 GRATED_SURFACES_MODE_UNKNOWN=0
+uint8 GRATED_SURFACES_MODE_OFF=1
+uint8 GRATED_SURFACES_MODE_ON=2
+uint8 GRATED_SURFACES_MODE_AUTO=3
+
+float32 ground_mu_hint
+uint8 grated_surfaces_mode

--- a/spot_msgs/srv/SetLocomotion.srv
+++ b/spot_msgs/srv/SetLocomotion.srv
@@ -1,4 +1,16 @@
-uint32 locomotion_mode # See https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference.html?highlight=mobilityparams#locomotionhint for details
+# See https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference.html?highlight=mobilityparams#locomotionhint for details
+uint8 HINT_UNKNOWN=0
+uint8 HINT_AUTO=1
+uint8 HINT_TROT=2
+uint8 HINT_SPEED_SELECT_TROT=3
+uint8 HINT_CRAWL=4
+uint8 HINT_AMBLE=5
+uint8 HINT_SPEED_SELECT_AMBLE=6
+uint8 HINT_JOG=7
+uint8 HINT_HOP=8
+uint8 HINT_SPEED_SELECT_CRAWL=10
+
+uint32 locomotion_mode
 ---
 bool success
 string message

--- a/spot_msgs/srv/SetObstacleParams.srv
+++ b/spot_msgs/srv/SetObstacleParams.srv
@@ -1,0 +1,4 @@
+spot_msgs/ObstacleParams obstacle_params
+---
+bool success
+string message

--- a/spot_msgs/srv/SetSwingHeight.srv
+++ b/spot_msgs/srv/SetSwingHeight.srv
@@ -1,0 +1,9 @@
+#see https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference.html?highlight=power_state#swingheight
+uint8 SWING_HEIGHT_LOW=1
+uint8 SWING_HEIGHT_MEDIUM=2
+uint8 SWING_HEIGHT_HIGH=3
+
+uint8 swing_height
+---
+bool success
+string message

--- a/spot_msgs/srv/SetSwingHeight.srv
+++ b/spot_msgs/srv/SetSwingHeight.srv
@@ -1,4 +1,5 @@
 #see https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference.html?highlight=power_state#swingheight
+uint8 SWING_HEIGHT_UNKNOWN=0
 uint8 SWING_HEIGHT_LOW=1
 uint8 SWING_HEIGHT_MEDIUM=2
 uint8 SWING_HEIGHT_HIGH=3

--- a/spot_msgs/srv/SetTerrainParams.srv
+++ b/spot_msgs/srv/SetTerrainParams.srv
@@ -1,0 +1,4 @@
+spot_msgs/TerrainParams terrain_params
+---
+bool success
+string message

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -223,194 +223,283 @@
       </layout>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="motionVelocityLayout">
-       <item>
-        <widget class="QLabel" name="motionCommandLabel">
-         <property name="text">
-          <string>Motion Velocity Limits</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="4" column="0">
-          <widget class="QLabel" name="angularZLabel">
-           <property name="text">
-            <string>Angular z</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="linearYLabel">
-           <property name="text">
-            <string>Linear y</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="linearXLabel">
-           <property name="text">
-            <string>Linear x</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QDoubleSpinBox" name="linearXSpin">
-           <property name="buttonSymbols">
-            <enum>QAbstractSpinBox::NoButtons</enum>
-           </property>
-           <property name="decimals">
-            <number>2</number>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QDoubleSpinBox" name="linearYSpin">
-           <property name="buttonSymbols">
-            <enum>QAbstractSpinBox::NoButtons</enum>
-           </property>
-           <property name="decimals">
-            <number>2</number>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QDoubleSpinBox" name="angularZSpin">
-           <property name="buttonSymbols">
-            <enum>QAbstractSpinBox::NoButtons</enum>
-           </property>
-           <property name="decimals">
-            <number>2</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="motionVelocityButtonsLayout">
+      <widget class="QTabWidget" name="tabWidget">
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <widget class="QWidget" name="motionTab">
+        <attribute name="title">
+         <string>Motion</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
          <item>
-          <widget class="QPushButton" name="setMaxVelButton">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="text">
-            <string>Set Velocity Limit</string>
-           </property>
-          </widget>
+          <layout class="QVBoxLayout" name="motionTabLayout">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QLabel" name="gaitLabel">
+               <property name="text">
+                <string>Gait</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="gaitComboBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="setGaitButton">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>Set</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="swingHeightLayout">
+             <item>
+              <widget class="QLabel" name="swingHeightLabel">
+               <property name="text">
+                <string>Swing height</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="swingHeightComboBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="setSwingHeightButton">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Set</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QVBoxLayout" name="motionVelocityLayout">
+             <item>
+              <widget class="QLabel" name="motionCommandLabel">
+               <property name="text">
+                <string>Motion Velocity Limits</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <layout class="QGridLayout" name="gridLayout">
+               <item row="4" column="0">
+                <widget class="QLabel" name="angularZLabel">
+                 <property name="text">
+                  <string>Angular z</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="linearYLabel">
+                 <property name="text">
+                  <string>Linear y</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="linearXLabel">
+                 <property name="text">
+                  <string>Linear x</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QDoubleSpinBox" name="linearXSpin">
+                 <property name="buttonSymbols">
+                  <enum>QAbstractSpinBox::NoButtons</enum>
+                 </property>
+                 <property name="decimals">
+                  <number>2</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QDoubleSpinBox" name="linearYSpin">
+                 <property name="buttonSymbols">
+                  <enum>QAbstractSpinBox::NoButtons</enum>
+                 </property>
+                 <property name="decimals">
+                  <number>2</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QDoubleSpinBox" name="angularZSpin">
+                 <property name="buttonSymbols">
+                  <enum>QAbstractSpinBox::NoButtons</enum>
+                 </property>
+                 <property name="decimals">
+                  <number>2</number>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QPushButton" name="setMaxVelButton">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>Set Velocity Limit</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
          </item>
         </layout>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QGridLayout" name="bodyPoseGridLayout">
-       <item row="1" column="0" colspan="2">
-        <widget class="QLabel" name="bodyPoseLabel">
-         <property name="text">
-          <string>Body Pose Control</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="rollLabel">
-         <property name="text">
-          <string>Roll</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="yawLabel">
-         <property name="text">
-          <string>Yaw</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0" colspan="2">
-        <widget class="QPushButton" name="setBodyPoseButton">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Set Body Pose</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="pitchLabel">
-         <property name="text">
-          <string>Pitch</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="bodyHeightLabel">
-         <property name="text">
-          <string>Body height</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QDoubleSpinBox" name="bodyHeightSpin">
-         <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::NoButtons</enum>
-         </property>
-         <property name="decimals">
-          <number>2</number>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QDoubleSpinBox" name="rollSpin">
-         <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::NoButtons</enum>
-         </property>
-         <property name="decimals">
-          <number>1</number>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QDoubleSpinBox" name="pitchSpin">
-         <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::NoButtons</enum>
-         </property>
-         <property name="decimals">
-          <number>1</number>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QDoubleSpinBox" name="yawSpin">
-         <property name="buttonSymbols">
-          <enum>QAbstractSpinBox::NoButtons</enum>
-         </property>
-         <property name="decimals">
-          <number>1</number>
-         </property>
-        </widget>
-       </item>
-      </layout>
+       </widget>
+       <widget class="QWidget" name="bodyTab">
+        <attribute name="title">
+         <string>Body</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <layout class="QGridLayout" name="bodyPoseGridLayout">
+           <item row="3" column="0">
+            <widget class="QLabel" name="rollLabel">
+             <property name="text">
+              <string>Roll</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="yawLabel">
+             <property name="text">
+              <string>Yaw</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0" colspan="2">
+            <widget class="QPushButton" name="setBodyPoseButton">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Set Body Pose</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="pitchLabel">
+             <property name="text">
+              <string>Pitch</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="bodyHeightLabel">
+             <property name="text">
+              <string>Body height</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QDoubleSpinBox" name="bodyHeightSpin">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="decimals">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QDoubleSpinBox" name="rollSpin">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QDoubleSpinBox" name="pitchSpin">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QDoubleSpinBox" name="yawSpin">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QLabel" name="bodyPoseLabel">
+             <property name="text">
+              <string>Body Pose Control</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </widget>
      </item>
      <item>
       <widget class="QLabel" name="statusLabel">

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -75,6 +75,13 @@
       </layout>
      </item>
      <item>
+      <widget class="QLabel" name="estopLabel">
+       <property name="text">
+        <string>E-stops</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="releaseStopButton">
        <property name="enabled">
         <bool>false</bool>

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -68,10 +68,10 @@
       </font>
      </property>
      <property name="toolTip">
-      <string>Soft stop, stops whatever the robot is doing</string>
+      <string>Gentle e-stop, stops whatever the robot is doing and then sits down</string>
      </property>
      <property name="text">
-      <string>Stop</string>
+      <string>Gentle E-stop</string>
      </property>
     </widget>
    </item>
@@ -81,7 +81,41 @@
       <string>Release the emergency stop</string>
      </property>
      <property name="text">
-      <string>Release Stop</string>
+      <string>Release E-stop</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QPushButton" name="stopButton">
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>300</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>25</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>Stop any action the robot is taking but do not sit down or kill motor power</string>
+     </property>
+     <property name="text">
+      <string>Stop Action</string>
      </property>
     </widget>
    </item>

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -192,7 +192,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>Set Max Velocity</string>
+            <string>Set Velocity Limit</string>
            </property>
           </widget>
          </item>

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>456</width>
+    <width>428</width>
     <height>855</height>
    </rect>
   </property>
@@ -15,33 +15,80 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QVBoxLayout" name="estopLayout">
      <item>
-      <widget class="QPushButton" name="hardStopButton">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QPushButton" name="gentleStopButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="baseSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>18</pointsize>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string>Gentle e-stop, stops whatever the robot is doing and then sits down</string>
+         </property>
+         <property name="text">
+          <string>Gentle E-stop</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="hardStopButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>18</pointsize>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string>Hard emergency stop, kills power to motors</string>
+         </property>
+         <property name="text">
+          <string>Kill Motors</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QPushButton" name="releaseStopButton">
        <property name="enabled">
         <bool>false</bool>
        </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>18</pointsize>
-        </font>
-       </property>
        <property name="toolTip">
-        <string>Hard emergency stop, kills power to motors</string>
+        <string>Release the emergency stop</string>
        </property>
        <property name="text">
-        <string>Kill Motors</string>
+        <string>Release E-stop</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="gentleStopButton">
+      <widget class="QPushButton" name="stopButton">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -59,61 +106,18 @@
        </property>
        <property name="font">
         <font>
-         <pointsize>18</pointsize>
+         <pointsize>15</pointsize>
         </font>
        </property>
        <property name="toolTip">
-        <string>Gentle e-stop, stops whatever the robot is doing and then sits down</string>
+        <string>Stop any action the robot is taking but do not sit down or kill motor power</string>
        </property>
        <property name="text">
-        <string>Gentle E-stop</string>
+        <string>Stop Action</string>
        </property>
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QPushButton" name="releaseStopButton">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="toolTip">
-      <string>Release the emergency stop</string>
-     </property>
-     <property name="text">
-      <string>Release E-stop</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="stopButton">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="baseSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>15</pointsize>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>Stop any action the robot is taking but do not sit down or kill motor power</string>
-     </property>
-     <property name="text">
-      <string>Stop Action</string>
-     </property>
-    </widget>
    </item>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
@@ -139,54 +143,60 @@
       </layout>
      </item>
      <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="powerLayout">
+      <layout class="QVBoxLayout" name="powerLayout">
        <item>
-        <widget class="QPushButton" name="powerOnButton">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
+        <layout class="QHBoxLayout" name="powerButtonLayout">
+         <item>
+          <widget class="QPushButton" name="powerOnButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Power On</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="powerOffButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Power Off</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="motorStateLabel">
          <property name="text">
-          <string>Power On</string>
+          <string>Motor state</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="powerOffButton">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
+        <widget class="QLabel" name="estimatedRuntimeLabel">
          <property name="text">
-          <string>Power Off</string>
+          <string>Estimated runtime</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="batteryStateLabel">
+         <property name="text">
+          <string>Battery state</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="batteryTempLabel">
+         <property name="text">
+          <string>Battery temp</string>
          </property>
         </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
      </item>
      <item>
       <layout class="QHBoxLayout" name="sitStandLayout">

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -238,7 +238,7 @@
      <item>
       <widget class="QTabWidget" name="tabWidget">
        <property name="currentIndex">
-        <number>2</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="motionTab">
         <attribute name="title">

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -7,13 +7,84 @@
     <x>0</x>
     <y>0</y>
     <width>456</width>
-    <height>618</height>
+    <height>855</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QPushButton" name="hardStopButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>30</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>Hard emergency stop, kills power to motors</string>
+     </property>
+     <property name="text">
+      <string>Kill Motor Power</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QPushButton" name="gentleStopButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>300</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>30</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>Soft stop, stops whatever the robot is doing</string>
+     </property>
+     <property name="text">
+      <string>Stop</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="releaseStopButton">
+     <property name="toolTip">
+      <string>Release the emergency stop</string>
+     </property>
+     <property name="text">
+      <string>Release Stop</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -235,65 +235,34 @@
          <item>
           <layout class="QVBoxLayout" name="motionTabLayout">
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <layout class="QHBoxLayout" name="obstaclePaddingLayout">
              <item>
-              <widget class="QLabel" name="gaitLabel">
+              <widget class="QLabel" name="obstaclePaddingLabel">
                <property name="text">
-                <string>Gait</string>
+                <string>Obstacle padding</string>
+               </property>
+               <property name="buddy">
+                <cstring>obstaclePaddingSpin</cstring>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QComboBox" name="gaitComboBox">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+              <widget class="QDoubleSpinBox" name="obstaclePaddingSpin">
+               <property name="decimals">
+                <number>2</number>
+               </property>
+               <property name="maximum">
+                <double>0.500000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QPushButton" name="setGaitButton">
+              <widget class="QPushButton" name="setObstaclePaddingButton">
                <property name="enabled">
                 <bool>false</bool>
-               </property>
-               <property name="text">
-                <string>Set</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="swingHeightLayout">
-             <item>
-              <widget class="QLabel" name="swingHeightLabel">
-               <property name="text">
-                <string>Swing height</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="swingHeightComboBox">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="setSwingHeightButton">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
                </property>
                <property name="text">
                 <string>Set</string>
@@ -321,6 +290,9 @@
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
+                 <property name="buddy">
+                  <cstring>angularZSpin</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="3" column="0">
@@ -331,6 +303,9 @@
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
+                 <property name="buddy">
+                  <cstring>linearYSpin</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="1" column="0">
@@ -340,6 +315,9 @@
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="buddy">
+                  <cstring>linearXSpin</cstring>
                  </property>
                 </widget>
                </item>
@@ -382,6 +360,159 @@
                </property>
                <property name="text">
                 <string>Set Velocity Limit</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="advancedMotionTab">
+        <attribute name="title">
+         <string>Adv. Motion</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <item>
+          <layout class="QVBoxLayout" name="advancedMotionLayout">
+           <item>
+            <layout class="QGridLayout" name="gridLayout_2">
+             <item row="2" column="1">
+              <widget class="QComboBox" name="gratedSurfacesComboBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="2">
+              <widget class="QPushButton" name="setGratedSurfacesButton">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>Set</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="swingHeightLabel">
+               <property name="text">
+                <string>Swing height</string>
+               </property>
+               <property name="buddy">
+                <cstring>swingHeightComboBox</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QPushButton" name="setSwingHeightButton">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Set</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="gaitComboBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QPushButton" name="setGaitButton">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>Set</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="gaitLabel">
+               <property name="text">
+                <string>Gait</string>
+               </property>
+               <property name="buddy">
+                <cstring>gaitComboBox</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QComboBox" name="swingHeightComboBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="gratedSurfacesLabel">
+               <property name="text">
+                <string>Grated surface mode</string>
+               </property>
+               <property name="buddy">
+                <cstring>gratedSurfacesComboBox</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="frictionLabel">
+               <property name="text">
+                <string>Ground mu</string>
+               </property>
+               <property name="buddy">
+                <cstring>frictionSpin</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QDoubleSpinBox" name="frictionSpin">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimum">
+                <double>0.200000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>0.800000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>0.600000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="2">
+              <widget class="QPushButton" name="setFrictionButton">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>Set</string>
                </property>
               </widget>
              </item>
@@ -515,6 +646,30 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>gentleStopButton</tabstop>
+  <tabstop>hardStopButton</tabstop>
+  <tabstop>releaseStopButton</tabstop>
+  <tabstop>stopButton</tabstop>
+  <tabstop>claimLeaseButton</tabstop>
+  <tabstop>releaseLeaseButton</tabstop>
+  <tabstop>powerOnButton</tabstop>
+  <tabstop>powerOffButton</tabstop>
+  <tabstop>sitButton</tabstop>
+  <tabstop>standButton</tabstop>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>obstaclePaddingSpin</tabstop>
+  <tabstop>setObstaclePaddingButton</tabstop>
+  <tabstop>linearXSpin</tabstop>
+  <tabstop>linearYSpin</tabstop>
+  <tabstop>angularZSpin</tabstop>
+  <tabstop>setMaxVelButton</tabstop>
+  <tabstop>bodyHeightSpin</tabstop>
+  <tabstop>rollSpin</tabstop>
+  <tabstop>pitchSpin</tabstop>
+  <tabstop>yawSpin</tabstop>
+  <tabstop>setBodyPoseButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -113,11 +113,24 @@
         <string>Stop any action the robot is taking but do not sit down or kill motor power</string>
        </property>
        <property name="text">
-        <string>Stop Action</string>
+        <string>Stop</string>
        </property>
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QPushButton" name="allowMotionButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string>Allow or disallow motion of the robot</string>
+     </property>
+     <property name="text">
+      <string>Disallow motion</string>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
@@ -225,7 +238,7 @@
      <item>
       <widget class="QTabWidget" name="tabWidget">
        <property name="currentIndex">
-        <number>0</number>
+        <number>2</number>
        </property>
        <widget class="QWidget" name="motionTab">
         <attribute name="title">
@@ -647,10 +660,9 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>gentleStopButton</tabstop>
-  <tabstop>hardStopButton</tabstop>
   <tabstop>releaseStopButton</tabstop>
   <tabstop>stopButton</tabstop>
+  <tabstop>allowMotionButton</tabstop>
   <tabstop>claimLeaseButton</tabstop>
   <tabstop>releaseLeaseButton</tabstop>
   <tabstop>powerOnButton</tabstop>
@@ -664,11 +676,21 @@
   <tabstop>linearYSpin</tabstop>
   <tabstop>angularZSpin</tabstop>
   <tabstop>setMaxVelButton</tabstop>
+  <tabstop>gaitComboBox</tabstop>
+  <tabstop>setGaitButton</tabstop>
+  <tabstop>swingHeightComboBox</tabstop>
+  <tabstop>setSwingHeightButton</tabstop>
+  <tabstop>gratedSurfacesComboBox</tabstop>
+  <tabstop>setGratedSurfacesButton</tabstop>
+  <tabstop>frictionSpin</tabstop>
+  <tabstop>setFrictionButton</tabstop>
   <tabstop>bodyHeightSpin</tabstop>
   <tabstop>rollSpin</tabstop>
   <tabstop>pitchSpin</tabstop>
   <tabstop>yawSpin</tabstop>
   <tabstop>setBodyPoseButton</tabstop>
+  <tabstop>gentleStopButton</tabstop>
+  <tabstop>hardStopButton</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -15,68 +15,68 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QPushButton" name="hardStopButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>30</pointsize>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>Hard emergency stop, kills power to motors</string>
-     </property>
-     <property name="text">
-      <string>Kill Motor Power</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QPushButton" name="gentleStopButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="baseSize">
-      <size>
-       <width>0</width>
-       <height>300</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>30</pointsize>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>Gentle e-stop, stops whatever the robot is doing and then sits down</string>
-     </property>
-     <property name="text">
-      <string>Gentle E-stop</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="hardStopButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>18</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>Hard emergency stop, kills power to motors</string>
+       </property>
+       <property name="text">
+        <string>Kill Motors</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="gentleStopButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="baseSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>18</pointsize>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>Gentle e-stop, stops whatever the robot is doing and then sits down</string>
+       </property>
+       <property name="text">
+        <string>Gentle E-stop</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QPushButton" name="releaseStopButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="toolTip">
       <string>Release the emergency stop</string>
      </property>
@@ -86,29 +86,25 @@
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_4">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <widget class="QPushButton" name="stopButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="baseSize">
       <size>
        <width>0</width>
-       <height>300</height>
+       <height>0</height>
       </size>
      </property>
      <property name="font">
       <font>
-       <pointsize>25</pointsize>
+       <pointsize>15</pointsize>
       </font>
      </property>
      <property name="toolTip">

--- a/spot_viz/rviz/robot.rviz
+++ b/spot_viz/rviz/robot.rviz
@@ -7,7 +7,7 @@ Panels:
         - /Global Options1
         - /Status1
       Splitter Ratio: 0.5
-    Tree Height: 437
+    Tree Height: 802
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -26,7 +26,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: ""
+    SyncSource: FrontLeftDepthCloud
   - Class: spot_viz/SpotControlPanel
     Name: SpotControlPanel
 Preferences:
@@ -64,6 +64,110 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        body:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bottom_screws_center:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        camera_bottom_screw_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        camera_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_left_hip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_left_lower_leg:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_left_upper_leg:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_rail:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        front_right_hip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_right_lower_leg:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_right_upper_leg:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        frontier_mount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        os_sensor:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        realsense_parent:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        rear_left_hip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        rear_left_lower_leg:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        rear_left_upper_leg:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        rear_rail:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        rear_right_hip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        rear_right_lower_leg:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        rear_right_upper_leg:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
       Name: RobotModel
       Robot Description: robot_description
       TF Prefix: ""
@@ -75,6 +179,80 @@ Visualization Manager:
       Frame Timeout: 15
       Frames:
         All Enabled: true
+        back:
+          Value: true
+        back_fisheye:
+          Value: true
+        base_link:
+          Value: true
+        body:
+          Value: true
+        bottom_screws_center:
+          Value: true
+        camera_bottom_screw_frame:
+          Value: true
+        camera_link:
+          Value: true
+        flat_body:
+          Value: true
+        front_left_hip:
+          Value: true
+        front_left_lower_leg:
+          Value: true
+        front_left_upper_leg:
+          Value: true
+        front_rail:
+          Value: true
+        front_right_hip:
+          Value: true
+        front_right_lower_leg:
+          Value: true
+        front_right_upper_leg:
+          Value: true
+        frontier_mount:
+          Value: true
+        frontleft:
+          Value: true
+        frontleft_fisheye:
+          Value: true
+        frontright:
+          Value: true
+        frontright_fisheye:
+          Value: true
+        gpe:
+          Value: true
+        head:
+          Value: true
+        left:
+          Value: true
+        left_fisheye:
+          Value: true
+        odom:
+          Value: true
+        os_sensor:
+          Value: true
+        realsense_parent:
+          Value: true
+        rear_left_hip:
+          Value: true
+        rear_left_lower_leg:
+          Value: true
+        rear_left_upper_leg:
+          Value: true
+        rear_rail:
+          Value: true
+        rear_right_hip:
+          Value: true
+        rear_right_lower_leg:
+          Value: true
+        rear_right_upper_leg:
+          Value: true
+        right:
+          Value: true
+        right_fisheye:
+          Value: true
+        vision:
+          Value: true
       Marker Alpha: 1
       Marker Scale: 0.25
       Name: TF
@@ -82,7 +260,60 @@ Visualization Manager:
       Show Axes: true
       Show Names: true
       Tree:
-        {}
+        odom:
+          body:
+            base_link:
+              {}
+            flat_body:
+              {}
+            front_left_hip:
+              front_left_upper_leg:
+                front_left_lower_leg:
+                  {}
+            front_rail:
+              frontier_mount:
+                bottom_screws_center:
+                  {}
+                os_sensor:
+                  {}
+                realsense_parent:
+                  camera_bottom_screw_frame:
+                    camera_link:
+                      {}
+            front_right_hip:
+              front_right_upper_leg:
+                front_right_lower_leg:
+                  {}
+            head:
+              back:
+                back_fisheye:
+                  {}
+              frontleft:
+                frontleft_fisheye:
+                  {}
+              frontright:
+                frontright_fisheye:
+                  {}
+              left:
+                left_fisheye:
+                  {}
+              right:
+                right_fisheye:
+                  {}
+            rear_left_hip:
+              rear_left_upper_leg:
+                rear_left_lower_leg:
+                  {}
+            rear_rail:
+              {}
+            rear_right_hip:
+              rear_right_upper_leg:
+                rear_right_lower_leg:
+                  {}
+            vision:
+              {}
+          gpe:
+            {}
       Update Interval: 0
       Value: true
     - Class: rviz/Group
@@ -93,8 +324,8 @@ Visualization Manager:
             Value: true
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 2.4536328315734863
-            Min Value: -0.15558075904846191
+            Max Value: 1.5422112941741943
+            Min Value: -13.729979515075684
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -129,8 +360,8 @@ Visualization Manager:
             Value: true
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 2.6121129989624023
-            Min Value: -0.1127399206161499
+            Max Value: 2.3710060119628906
+            Min Value: -6.938358306884766
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -165,8 +396,8 @@ Visualization Manager:
             Value: true
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 1.413526177406311
-            Min Value: -0.12897947430610657
+            Max Value: 1.8236514329910278
+            Min Value: -2.351337194442749
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -201,8 +432,8 @@ Visualization Manager:
             Value: true
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 1.4527443647384644
-            Min Value: -0.12478607892990112
+            Max Value: 2.603226661682129
+            Min Value: -3.571293830871582
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -237,8 +468,8 @@ Visualization Manager:
             Value: true
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
-            Max Value: 0.6556414365768433
-            Min Value: -0.08529064059257507
+            Max Value: 1.576756477355957
+            Min Value: -2.3970136642456055
             Value: true
           Axis: Z
           Channel Name: intensity
@@ -271,13 +502,13 @@ Visualization Manager:
       Name: DepthClouds
     - Class: rviz/InteractiveMarkers
       Enable Transparency: true
-      Enabled: true
+      Enabled: false
       Name: InteractiveMarkers
       Show Axes: false
       Show Descriptions: true
       Show Visual Aids: false
       Update Topic: /twist_marker_server/update
-      Value: true
+      Value: false
     - Class: rviz/TF
       Enabled: false
       Frame Timeout: 15
@@ -321,7 +552,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 4.597156524658203
+      Distance: 10
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
@@ -329,25 +560,25 @@ Visualization Manager:
         Value: false
       Field of View: 0.7853981852531433
       Focal Point:
-        X: -0.09166686236858368
-        Y: 0.17000189423561096
-        Z: 0.21145612001419067
+        X: 0
+        Y: 0
+        Z: 0
       Focal Shape Fixed Size: false
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.5303988456726074
+      Pitch: 0.7853981852531433
       Target Frame: <Fixed Frame>
-      Yaw: 4.322348594665527
+      Yaw: 0.7853981852531433
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
   Height: 1016
   Hide Left Dock: false
-  Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd0000000400000000000002ad0000035afc0200000012fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000001f2000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000280020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006700000002300000018e0000000000000000fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000000a0049006d00610067006501000002f4000000ca0000000000000000fb0000000a0049006d00610067006501000002f4000000ca0000000000000000fb0000000a0049006d006100670065000000013f000000660000000000000000fb0000000a0049006d0061006700650000000164000000940000000000000000fb0000000a0049006d00610067006500000001a3000000e80000000000000000fc00000227000001970000000000fffffffa000000000100000002fb0000000a0049006d0061006700650000000000ffffffff0000000000000000fb0000000a0049006d0061006700650000000000000002ad0000000000000000fb0000002000530070006f00740043006f006e00740072006f006c00500061006e0065006c0100000235000001620000016200ffffff000000010000010f00000396fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002800000396000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d0065010000000000000780000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004cd0000035a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001680000035ffc0200000011fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000035f000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000280020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006700000002300000018e0000000000000000fb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000000a0049006d00610067006501000002f4000000ca0000000000000000fb0000000a0049006d00610067006501000002f4000000ca0000000000000000fb0000000a0049006d006100670065000000013f000000660000000000000000fb0000000a0049006d0061006700650000000164000000940000000000000000fb0000000a0049006d00610067006500000001a3000000e80000000000000000fc00000227000001970000000000fffffffa000000000100000002fb0000000a0049006d0061006700650000000000ffffffff0000000000000000fb0000000a0049006d0061006700650000000000000002ad000000000000000000000001000001b80000035ffc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fc0000003d0000035f000002b70100001cfa000000000100000002fb0000002000530070006f00740043006f006e00740072006f006c00500061006e0065006c0100000000ffffffff000001b800fffffffb0000000a0056006900650077007301000005c8000001b80000010000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000078000000039fc0100000002fb0000000800540069006d0065010000000000000780000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004540000035f00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   SpotControlPanel:
@@ -357,7 +588,7 @@ Window Geometry:
   Tool Properties:
     collapsed: false
   Views:
-    collapsed: true
+    collapsed: false
   Width: 1920
   X: 0
   Y: 27

--- a/spot_viz/rviz/robot.rviz
+++ b/spot_viz/rviz/robot.rviz
@@ -313,7 +313,7 @@ Visualization Manager:
       X std deviation: 0.5
       Y std deviation: 0.5
     - Class: rviz/SetGoal
-      Topic: /move_base_simple/goal
+      Topic: /spot/go_to_pose
     - Class: rviz/PublishPoint
       Single click: true
       Topic: /clicked_point

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -48,6 +48,7 @@ namespace spot_viz
 
         leaseSub_ = nh_.subscribe("/spot/status/leases", 1, &ControlPanel::leaseCallback, this);
         estopSub_ = nh_.subscribe("/spot/status/estop", 1, &ControlPanel::estopCallback, this);
+        mobilityParamsSub_ = nh_.subscribe("/spot/status/mobility_params", 1, &ControlPanel::mobilityParamsCallback, this);
 
         claimLeaseButton = this->findChild<QPushButton*>("claimLeaseButton");
         releaseLeaseButton = this->findChild<QPushButton*>("releaseLeaseButton");
@@ -235,6 +236,19 @@ namespace spot_viz
             isEStopped = msg_is_estopped;
             setControlButtons();
         }
+    }
+
+    void ControlPanel::mobilityParamsCallback(const spot_msgs::MobilityParams::ConstPtr &params) {
+        if (*params == _lastMobilityParams) {
+            // If we don't check this, the user will never be able to modify values since they will constantly reset
+            return;
+        } else {
+            linearXSpin->setValue(params->velocity_limit.linear.x);
+            linearYSpin->setValue(params->velocity_limit.linear.y);
+            angularZSpin->setValue(params->velocity_limit.angular.z);
+        }
+
+        _lastMobilityParams = *params;
     }
 
     void ControlPanel::sit() {

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -454,16 +454,22 @@ namespace spot_viz
         case spot_msgs::PowerState::STATE_POWERING_OFF:
             state = "Powering off";
             powerOffButton->setEnabled(false);
+            sitButton->setEnabled(false);
+            standButton->setEnabled(false);
             break;
         case spot_msgs::PowerState::STATE_ON:
             state = "On";
             powerOnButton->setEnabled(false);
             powerOffButton->setEnabled(true);
+            sitButton->setEnabled(true);
+            standButton->setEnabled(true);
             break;
         case spot_msgs::PowerState::STATE_OFF:
             state = "Off";
             powerOnButton->setEnabled(true && haveLease);
             powerOffButton->setEnabled(false);
+            sitButton->setEnabled(false);
+            standButton->setEnabled(false);
             break;
         case spot_msgs::PowerState::STATE_ERROR:
             state = "Error";

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -42,6 +42,7 @@ namespace spot_viz
         hardStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/hard");
         gentleStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/gentle");
         releaseStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/release");
+        stopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/stop");
         bodyPosePub_ = nh_.advertise<geometry_msgs::Pose>("/spot/body_pose", 1);
 
         leaseSub_ = nh_.subscribe("/spot/status/leases", 1, &ControlPanel::leaseCallback, this);
@@ -56,9 +57,16 @@ namespace spot_viz
         setMaxVelButton = this->findChild<QPushButton*>("setMaxVelButton");
         statusLabel = this->findChild<QLabel*>("statusLabel");
 
-        gentleStopButton = this->findChild<QPushButton*>("gentleStopButton");
-        QPalette pal = gentleStopButton->palette();
+        stopButton = this->findChild<QPushButton*>("stopButton");
+        QPalette pal = stopButton->palette();
         pal.setColor(QPalette::Button, QColor(255, 165, 0));
+        stopButton->setAutoFillBackground(true);
+        stopButton->setPalette(pal);
+        stopButton->update();
+
+        gentleStopButton = this->findChild<QPushButton*>("gentleStopButton");
+        pal = gentleStopButton->palette();
+        pal.setColor(QPalette::Button, QColor(255, 0, 255));
         gentleStopButton->setAutoFillBackground(true);
         gentleStopButton->setPalette(pal);
         gentleStopButton->update();
@@ -136,6 +144,7 @@ namespace spot_viz
         connect(releaseStopButton, SIGNAL(clicked()), this, SLOT(releaseStop()));
         connect(hardStopButton, SIGNAL(clicked()), this, SLOT(hardStop()));
         connect(gentleStopButton, SIGNAL(clicked()), this, SLOT(gentleStop()));
+        connect(stopButton, SIGNAL(clicked()), this, SLOT(stop()));
         
     }
 
@@ -228,6 +237,10 @@ namespace spot_viz
     void ControlPanel::releaseLease() {
         if (callTriggerService(releaseLeaseService_, "release lease"))
             releaseLeaseButton->setEnabled(false);
+    }
+
+    void ControlPanel::stop() {
+        callTriggerService(stopService_, "stop");
     }
 
     void ControlPanel::hardStop() {

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -85,6 +85,10 @@ namespace spot_viz
         obstaclePaddingSpin = this->findChild<QDoubleSpinBox*>("obstaclePaddingSpin");
         frictionSpin = this->findChild<QDoubleSpinBox*>("frictionSpin");
 
+        setupComboBoxes();
+        setupStopButtons();
+        setupSpinBoxes();
+
         // Subscribe to things after everything is set up to avoid crashes when things aren't initialised
         leaseSub_ = nh_.subscribe("/spot/status/leases", 1, &ControlPanel::leaseCallback, this);
         estopSub_ = nh_.subscribe("/spot/status/estop", 1, &ControlPanel::estopCallback, this);
@@ -92,10 +96,6 @@ namespace spot_viz
         batterySub_ = nh_.subscribe("/spot/status/battery_states", 1, &ControlPanel::batteryCallback, this);
         powerSub_ = nh_.subscribe("/spot/status/power_state", 1, &ControlPanel::powerCallback, this);
         motionAllowedSub_ = nh_.subscribe("/spot/status/motion_allowed", 1, &ControlPanel::motionAllowedCallback, this);
-
-        setupComboBoxes();
-        setupStopButtons();
-        setupSpinBoxes();
 
         connect(claimLeaseButton, SIGNAL(clicked()), this, SLOT(claimLease()));
         connect(releaseLeaseButton, SIGNAL(clicked()), this, SLOT(releaseLease()));

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -56,47 +56,47 @@ namespace spot_viz
         double linearVelocityLimit = 2;
         linearXSpin = this->findChild<QDoubleSpinBox*>("linearXSpin");
         linearXLabel = this->findChild<QLabel*>("linearXLabel");
-        updateLabelTextWithLimit(linearXLabel, linearVelocityLimit);
+        updateLabelTextWithLimit(linearXLabel, 0, linearVelocityLimit);
         linearXSpin->setMaximum(linearVelocityLimit);
-        linearXSpin->setMinimum(-linearVelocityLimit);
+        linearXSpin->setMinimum(0);
 
         linearYSpin = this->findChild<QDoubleSpinBox*>("linearYSpin");
         linearYLabel = this->findChild<QLabel*>("linearYLabel");
-        updateLabelTextWithLimit(linearYLabel, linearVelocityLimit);
+        updateLabelTextWithLimit(linearYLabel, 0, linearVelocityLimit);
         linearYSpin->setMaximum(linearVelocityLimit);
-        linearYSpin->setMinimum(-linearVelocityLimit);
+        linearYSpin->setMinimum(0);
 
         angularZSpin = this->findChild<QDoubleSpinBox*>("angularZSpin");
         angularZLabel = this->findChild<QLabel*>("angularZLabel");
-        updateLabelTextWithLimit(angularZLabel, linearVelocityLimit);
+        updateLabelTextWithLimit(angularZLabel, 0, linearVelocityLimit);
         angularZSpin->setMaximum(linearVelocityLimit);
-        angularZSpin->setMinimum(-linearVelocityLimit);
+        angularZSpin->setMinimum(0);
 
-        double bodyHeightLimit = 0.3;
+        double bodyHeightLimit = 0.15;
         bodyHeightSpin = this->findChild<QDoubleSpinBox*>("bodyHeightSpin");
         bodyHeightLabel = this->findChild<QLabel*>("bodyHeightLabel");
-        updateLabelTextWithLimit(bodyHeightLabel, bodyHeightLimit);
+        updateLabelTextWithLimit(bodyHeightLabel, -bodyHeightLimit, bodyHeightLimit);
         bodyHeightSpin->setMaximum(bodyHeightLimit);
         bodyHeightSpin->setMinimum(-bodyHeightLimit);
 
         double rollLimit = 20;
         rollSpin = this->findChild<QDoubleSpinBox*>("rollSpin");
         rollLabel = this->findChild<QLabel*>("rollLabel");
-        updateLabelTextWithLimit(rollLabel, rollLimit);
+        updateLabelTextWithLimit(rollLabel, -rollLimit, rollLimit);
         rollSpin->setMaximum(rollLimit);
         rollSpin->setMinimum(-rollLimit);
 
         double pitchLimit = 30;
         pitchSpin = this->findChild<QDoubleSpinBox*>("pitchSpin");
         pitchLabel = this->findChild<QLabel*>("pitchLabel");
-        updateLabelTextWithLimit(pitchLabel, pitchLimit);
+        updateLabelTextWithLimit(pitchLabel, -pitchLimit, pitchLimit);
         pitchSpin->setMaximum(pitchLimit);
         pitchSpin->setMinimum(-pitchLimit);
 
         double yawLimit = 30;
         yawSpin = this->findChild<QDoubleSpinBox*>("yawSpin");
         yawLabel = this->findChild<QLabel*>("yawLabel");
-        updateLabelTextWithLimit(yawLabel, yawLimit);
+        updateLabelTextWithLimit(yawLabel, -yawLimit, yawLimit);
         yawSpin->setMaximum(yawLimit);
         yawSpin->setMinimum(-yawLimit);
 
@@ -110,13 +110,14 @@ namespace spot_viz
         connect(setMaxVelButton, SIGNAL(clicked()), this, SLOT(setMaxVel()));
     }
 
-    void ControlPanel::updateLabelTextWithLimit(QLabel* label, double limit) {
+    void ControlPanel::updateLabelTextWithLimit(QLabel* label, double limit_lower, double limit_upper) {
         int precision = 1;
         // Kind of hacky but default to_string returns 6 digit precision which is unnecessary
-        std::string limit_value = std::to_string(limit).substr(0, std::to_string(limit).find(".") + precision + 1);
-        std::string limit_range = " [-" + limit_value + ", " + limit_value + "]";
+        std::string limit_lower_value = std::to_string(limit_lower).substr(0, std::to_string(limit_lower).find(".") + precision + 1);
+        std::string limit_upper_value = std::to_string(limit_upper).substr(0, std::to_string(limit_upper).find(".") + precision + 1);
+        std::string limit_range = " [" + limit_lower_value + ", " + limit_upper_value + "]";
         std::string current_text = label->text().toStdString();
-        label->setText(QString((current_text+ limit_range).c_str()));
+        label->setText(QString((current_text + limit_range).c_str()));
     }
 
     void ControlPanel::setControlButtons() {

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -39,6 +39,9 @@ namespace spot_viz
         powerOnService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/power_on");
         powerOffService_ = nh_.serviceClient<std_srvs::Trigger>("spot/power_off");
         maxVelocityService_ = nh_.serviceClient<spot_msgs::SetVelocity>("/spot/velocity_limit");
+        hardStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/hard");
+        gentleStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/gentle");
+        releaseStopService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/estop/release");
         bodyPosePub_ = nh_.advertise<geometry_msgs::Pose>("/spot/body_pose", 1);
 
         leaseSub_ = nh_.subscribe("/spot/status/leases", 1, &ControlPanel::leaseCallback, this);
@@ -52,6 +55,28 @@ namespace spot_viz
         setBodyPoseButton = this->findChild<QPushButton*>("setBodyPoseButton");
         setMaxVelButton = this->findChild<QPushButton*>("setMaxVelButton");
         statusLabel = this->findChild<QLabel*>("statusLabel");
+
+        gentleStopButton = this->findChild<QPushButton*>("gentleStopButton");
+        QPalette pal = gentleStopButton->palette();
+        pal.setColor(QPalette::Button, QColor(255, 165, 0));
+        gentleStopButton->setAutoFillBackground(true);
+        gentleStopButton->setPalette(pal);
+        gentleStopButton->update();
+
+        hardStopButton = this->findChild<QPushButton*>("hardStopButton");
+        pal = hardStopButton->palette();
+        pal.setColor(QPalette::Button, QColor(255, 0, 0));
+        hardStopButton->setAutoFillBackground(true);
+        hardStopButton->setPalette(pal);
+        hardStopButton->update();
+
+        releaseStopButton = this->findChild<QPushButton*>("releaseStopButton");
+        pal = releaseStopButton->palette();
+        pal.setColor(QPalette::Button, QColor(0, 255, 0));
+        releaseStopButton->setAutoFillBackground(true);
+        releaseStopButton->setPalette(pal);
+        releaseStopButton->update();
+
 
         double linearVelocityLimit = 2;
         linearXSpin = this->findChild<QDoubleSpinBox*>("linearXSpin");
@@ -108,6 +133,10 @@ namespace spot_viz
         connect(standButton, SIGNAL(clicked()), this, SLOT(stand()));
         connect(setBodyPoseButton, SIGNAL(clicked()), this, SLOT(sendBodyPose()));
         connect(setMaxVelButton, SIGNAL(clicked()), this, SLOT(setMaxVel()));
+        connect(releaseStopButton, SIGNAL(clicked()), this, SLOT(releaseStop()));
+        connect(hardStopButton, SIGNAL(clicked()), this, SLOT(hardStop()));
+        connect(gentleStopButton, SIGNAL(clicked()), this, SLOT(gentleStop()));
+        
     }
 
     void ControlPanel::updateLabelTextWithLimit(QLabel* label, double limit_lower, double limit_upper) {
@@ -200,6 +229,18 @@ namespace spot_viz
         if (callTriggerService(releaseLeaseService_, "release lease"))
             releaseLeaseButton->setEnabled(false);
     }
+
+    void ControlPanel::hardStop() {
+        callTriggerService(hardStopService_, "hard stop");
+    }
+
+    void ControlPanel::gentleStop() {
+        callTriggerService(gentleStopService_, "gentle stop");
+    }
+
+    void ControlPanel::releaseStop() {
+        callTriggerService(releaseStopService_, "release stop");
+    }    
 
     void ControlPanel::setMaxVel() {
         spot_msgs::SetVelocity req;

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -38,7 +38,7 @@ namespace spot_viz
         releaseLeaseService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/release");
         powerOnService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/power_on");
         powerOffService_ = nh_.serviceClient<std_srvs::Trigger>("spot/power_off");
-        maxVelocityService_ = nh_.serviceClient<spot_msgs::SetVelocity>("/spot/max_velocity");
+        maxVelocityService_ = nh_.serviceClient<spot_msgs::SetVelocity>("/spot/velocity_limit");
         bodyPosePub_ = nh_.advertise<geometry_msgs::Pose>("/spot/body_pose", 1);
 
         leaseSub_ = nh_.subscribe("/spot/status/leases", 1, &ControlPanel::leaseCallback, this);
@@ -206,18 +206,18 @@ namespace spot_viz
         req.request.velocity_limit.linear.x = linearXSpin->value();
         req.request.velocity_limit.linear.y = linearYSpin->value();
 
-        std::string labelText = "Calling set max velocity service";
+        std::string labelText = "Calling set velocity limit service";
         statusLabel->setText(QString(labelText.c_str()));
         if (maxVelocityService_.call(req)) {
             if (req.response.success) {
-                labelText = "Successfully called set max velocity service";
+                labelText = "Successfully called set velocity limit service";
                 statusLabel->setText(QString(labelText.c_str()));
             } else {
-                labelText = "set max velocity service failed: " + req.response.message;
+                labelText = "set velocity limit service failed: " + req.response.message;
                 statusLabel->setText(QString(labelText.c_str()));
             }
         } else {
-            labelText = "Failed to call set max velocity service" + req.response.message;
+            labelText = "Failed to call set velocity limit service" + req.response.message;
             statusLabel->setText(QString(labelText.c_str()));
         }
     }

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -7,6 +7,7 @@
 # include <rviz/panel.h>
 #endif
 
+#include <map>
 #include <QPushButton>
 #include <QLabel>
 #include <QDoubleSpinBox>
@@ -14,7 +15,9 @@
 #include <spot_msgs/LeaseArray.h>
 #include <spot_msgs/EStopStateArray.h>
 #include <spot_msgs/MobilityParams.h>
-
+#include <spot_msgs/TerrainParams.h>
+#include <spot_msgs/SetSwingHeight.h>
+#include <spot_msgs/SetLocomotion.h>
 #include <spot_msgs/BatteryStateArray.h>
 #include <spot_msgs/PowerState.h>
 
@@ -46,12 +49,49 @@ class ControlPanel : public rviz::Panel
     void stop();
     void setGait();
     void setSwingHeight();
+    void setTerrainParams();
+    void setObstacleParams();
 
     private:
 
+    // These maps allow us to set up the comboboxes for selections in the order
+    // of the enum, and ensure that the correct value is sent when the user wants to set it
+    // We can also use them to ensure that non-consecutive values are also correctly handled
+    const std::map<uint, std::string> gaitMap = {
+        {spot_msgs::SetLocomotion::Request::HINT_UNKNOWN, "Unknown"},
+        {spot_msgs::SetLocomotion::Request::HINT_TROT, "Trot"},
+        {spot_msgs::SetLocomotion::Request::HINT_SPEED_SELECT_TROT, "Speed sel trot"},
+        {spot_msgs::SetLocomotion::Request::HINT_CRAWL, "Crawl"},
+        {spot_msgs::SetLocomotion::Request::HINT_AMBLE, "Amble"},
+        {spot_msgs::SetLocomotion::Request::HINT_SPEED_SELECT_AMBLE, "Speed sel amble"},
+        {spot_msgs::SetLocomotion::Request::HINT_AUTO,  "Auto"},
+        {spot_msgs::SetLocomotion::Request::HINT_JOG, "Jog"},
+        {spot_msgs::SetLocomotion::Request::HINT_HOP, "Hop"},
+        {spot_msgs::SetLocomotion::Request::HINT_SPEED_SELECT_CRAWL, "Speed sel crawl"}
+    };
+
+    const std::map<uint, std::string> swingHeightMap = {
+        {spot_msgs::SetSwingHeight::Request::SWING_HEIGHT_UNKNOWN, "Unknown"},
+        {spot_msgs::SetSwingHeight::Request::SWING_HEIGHT_LOW, "Low"},
+        {spot_msgs::SetSwingHeight::Request::SWING_HEIGHT_MEDIUM, "Medium"},
+        {spot_msgs::SetSwingHeight::Request::SWING_HEIGHT_HIGH, "High"}
+    };
+
+    const std::map<uint, std::string> gratedSurfacesMap = {
+        {spot_msgs::TerrainParams::GRATED_SURFACES_MODE_UNKNOWN, "Unknown"},
+        {spot_msgs::TerrainParams::GRATED_SURFACES_MODE_OFF, "Off"},
+        {spot_msgs::TerrainParams::GRATED_SURFACES_MODE_ON, "On"},
+        {spot_msgs::TerrainParams::GRATED_SURFACES_MODE_AUTO, "Auto"}
+    };
+
+    void setupComboBoxes();
+    void setupStopButtons();
+    void setupSpinBoxes();
     void setControlButtons();
     void toggleBodyPoseButtons();
     bool callTriggerService(ros::ServiceClient service, std::string serviceName);
+    template <typename T>
+    bool callCustomTriggerService(ros::ServiceClient service, std::string serviceName, T serviceRequest);
     void updateLabelTextWithLimit(QLabel* label, double limit_lower, double limit_upper);
     void leaseCallback(const spot_msgs::LeaseArray::ConstPtr &leases);
     void estopCallback(const spot_msgs::EStopStateArray::ConstPtr &estops);
@@ -73,6 +113,8 @@ class ControlPanel : public rviz::Panel
     ros::ServiceClient stopService_;
     ros::ServiceClient gaitService_;
     ros::ServiceClient swingHeightService_;
+    ros::ServiceClient terrainParamsService_;
+    ros::ServiceClient obstacleParamsService_;
     ros::Publisher bodyPosePub_;
     ros::Subscriber leaseSub_;
     ros::Subscriber estopSub_;
@@ -94,6 +136,9 @@ class ControlPanel : public rviz::Panel
     QPushButton* stopButton;
     QPushButton* setGaitButton;
     QPushButton* setSwingHeightButton;
+    QPushButton* setObstaclePaddingButton;
+    QPushButton* setGratedSurfacesButton;
+    QPushButton* setFrictionButton;
 
     QLabel* linearXLabel;
     QLabel* linearYLabel;
@@ -110,6 +155,7 @@ class ControlPanel : public rviz::Panel
 
     QComboBox* gaitComboBox;
     QComboBox* swingHeightComboBox;
+    QComboBox* gratedSurfacesComboBox;
 
     QDoubleSpinBox* linearXSpin;
     QDoubleSpinBox* linearYSpin;
@@ -118,6 +164,8 @@ class ControlPanel : public rviz::Panel
     QDoubleSpinBox* rollSpin;
     QDoubleSpinBox* pitchSpin;
     QDoubleSpinBox* yawSpin;
+    QDoubleSpinBox* frictionSpin;
+    QDoubleSpinBox* obstaclePaddingSpin;
 
     spot_msgs::MobilityParams _lastMobilityParams;
 

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -39,7 +39,7 @@ class ControlPanel : public rviz::Panel
     void setControlButtons();
     void toggleBodyPoseButtons();
     bool callTriggerService(ros::ServiceClient service, std::string serviceName);
-    void updateLabelTextWithLimit(QLabel* label, double limit);
+    void updateLabelTextWithLimit(QLabel* label, double limit, double limit_lower=0);
     void leaseCallback(const spot_msgs::LeaseArray::ConstPtr &leases);
 
     ros::NodeHandle nh_;

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -14,6 +14,8 @@
 #include <spot_msgs/EStopStateArray.h>
 #include <spot_msgs/MobilityParams.h>
 
+#include <spot_msgs/BatteryStateArray.h>
+#include <spot_msgs/PowerState.h>
 
 namespace spot_viz
 {
@@ -50,6 +52,8 @@ class ControlPanel : public rviz::Panel
     void leaseCallback(const spot_msgs::LeaseArray::ConstPtr &leases);
     void estopCallback(const spot_msgs::EStopStateArray::ConstPtr &estops);
     void mobilityParamsCallback(const spot_msgs::MobilityParams::ConstPtr &params);
+    void batteryCallback(const spot_msgs::BatteryStateArray::ConstPtr &battery);
+    void powerCallback(const spot_msgs::PowerState::ConstPtr &power);
 
     ros::NodeHandle nh_;
     ros::ServiceClient sitService_;
@@ -67,6 +71,8 @@ class ControlPanel : public rviz::Panel
     ros::Subscriber leaseSub_;
     ros::Subscriber estopSub_;
     ros::Subscriber mobilityParamsSub_;
+    ros::Subscriber batterySub_;
+    ros::Subscriber powerSub_;
 
     QPushButton* claimLeaseButton;
     QPushButton* releaseLeaseButton;
@@ -88,6 +94,11 @@ class ControlPanel : public rviz::Panel
     QLabel* rollLabel;
     QLabel* pitchLabel;
     QLabel* yawLabel;
+    QLabel* estimatedRuntimeLabel;
+    QLabel* batteryStateLabel;
+    QLabel* motorStateLabel;
+    QLabel* batteryTempLabel;
+
     QDoubleSpinBox* linearXSpin;
     QDoubleSpinBox* linearYSpin;
     QDoubleSpinBox* angularZSpin;

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -10,12 +10,14 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QDoubleSpinBox>
+#include <QComboBox>
 #include <spot_msgs/LeaseArray.h>
 #include <spot_msgs/EStopStateArray.h>
 #include <spot_msgs/MobilityParams.h>
 
 #include <spot_msgs/BatteryStateArray.h>
 #include <spot_msgs/PowerState.h>
+
 
 namespace spot_viz
 {
@@ -42,6 +44,8 @@ class ControlPanel : public rviz::Panel
     void hardStop();
     void releaseStop();
     void stop();
+    void setGait();
+    void setSwingHeight();
 
     private:
 
@@ -67,6 +71,8 @@ class ControlPanel : public rviz::Panel
     ros::ServiceClient gentleStopService_;
     ros::ServiceClient releaseStopService_;
     ros::ServiceClient stopService_;
+    ros::ServiceClient gaitService_;
+    ros::ServiceClient swingHeightService_;
     ros::Publisher bodyPosePub_;
     ros::Subscriber leaseSub_;
     ros::Subscriber estopSub_;
@@ -86,6 +92,9 @@ class ControlPanel : public rviz::Panel
     QPushButton* gentleStopButton;
     QPushButton* releaseStopButton;
     QPushButton* stopButton;
+    QPushButton* setGaitButton;
+    QPushButton* setSwingHeightButton;
+
     QLabel* linearXLabel;
     QLabel* linearYLabel;
     QLabel* angularZLabel;
@@ -98,6 +107,9 @@ class ControlPanel : public rviz::Panel
     QLabel* batteryStateLabel;
     QLabel* motorStateLabel;
     QLabel* batteryTempLabel;
+
+    QComboBox* gaitComboBox;
+    QComboBox* swingHeightComboBox;
 
     QDoubleSpinBox* linearXSpin;
     QDoubleSpinBox* linearYSpin;

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -33,6 +33,9 @@ class ControlPanel : public rviz::Panel
     void powerOff();
     void sendBodyPose();
     void setMaxVel();
+    void gentleStop();
+    void hardStop();
+    void releaseStop();
 
     private:
 
@@ -50,6 +53,9 @@ class ControlPanel : public rviz::Panel
     ros::ServiceClient powerOnService_;
     ros::ServiceClient powerOffService_;
     ros::ServiceClient maxVelocityService_;
+    ros::ServiceClient hardStopService_;
+    ros::ServiceClient gentleStopService_;
+    ros::ServiceClient releaseStopService_;
     ros::Publisher bodyPosePub_;
     ros::Subscriber leaseSub_;
 
@@ -61,6 +67,9 @@ class ControlPanel : public rviz::Panel
     QPushButton* sitButton;
     QPushButton* standButton;
     QPushButton* setMaxVelButton;
+    QPushButton* hardStopButton;
+    QPushButton* gentleStopButton;
+    QPushButton* releaseStopButton;
     QLabel* linearXLabel;
     QLabel* linearYLabel;
     QLabel* angularZLabel;

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -12,11 +12,12 @@
 #include <QLabel>
 #include <QDoubleSpinBox>
 #include <QComboBox>
-#include <spot_msgs/LeaseArray.h>
+#include <std_msgs/Bool.h>
 #include <spot_msgs/EStopStateArray.h>
 #include <spot_msgs/MobilityParams.h>
 #include <spot_msgs/TerrainParams.h>
 #include <spot_msgs/SetSwingHeight.h>
+#include <spot_msgs/LeaseArray.h>
 #include <spot_msgs/SetLocomotion.h>
 #include <spot_msgs/BatteryStateArray.h>
 #include <spot_msgs/PowerState.h>
@@ -51,6 +52,7 @@ class ControlPanel : public rviz::Panel
     void setSwingHeight();
     void setTerrainParams();
     void setObstacleParams();
+    void allowMotion();
 
     private:
 
@@ -98,6 +100,7 @@ class ControlPanel : public rviz::Panel
     void mobilityParamsCallback(const spot_msgs::MobilityParams::ConstPtr &params);
     void batteryCallback(const spot_msgs::BatteryStateArray::ConstPtr &battery);
     void powerCallback(const spot_msgs::PowerState::ConstPtr &power);
+    void motionAllowedCallback(const std_msgs::Bool &motion_allowed);
 
     ros::NodeHandle nh_;
     ros::ServiceClient sitService_;
@@ -115,12 +118,15 @@ class ControlPanel : public rviz::Panel
     ros::ServiceClient swingHeightService_;
     ros::ServiceClient terrainParamsService_;
     ros::ServiceClient obstacleParamsService_;
+    ros::ServiceClient allowMotionService_;
+
     ros::Publisher bodyPosePub_;
     ros::Subscriber leaseSub_;
     ros::Subscriber estopSub_;
     ros::Subscriber mobilityParamsSub_;
     ros::Subscriber batterySub_;
     ros::Subscriber powerSub_;
+    ros::Subscriber motionAllowedSub_;
 
     QPushButton* claimLeaseButton;
     QPushButton* releaseLeaseButton;
@@ -139,6 +145,7 @@ class ControlPanel : public rviz::Panel
     QPushButton* setObstaclePaddingButton;
     QPushButton* setGratedSurfacesButton;
     QPushButton* setFrictionButton;
+    QPushButton* allowMotionButton;
 
     QLabel* linearXLabel;
     QLabel* linearYLabel;
@@ -171,6 +178,7 @@ class ControlPanel : public rviz::Panel
 
     bool haveLease;
     bool isEStopped;
+    bool motionAllowed;
 };
 
 } // end namespace spot_viz

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -12,6 +12,7 @@
 #include <QDoubleSpinBox>
 #include <spot_msgs/LeaseArray.h>
 #include <spot_msgs/EStopStateArray.h>
+#include <spot_msgs/MobilityParams.h>
 
 
 namespace spot_viz
@@ -48,6 +49,7 @@ class ControlPanel : public rviz::Panel
     void updateLabelTextWithLimit(QLabel* label, double limit_lower, double limit_upper);
     void leaseCallback(const spot_msgs::LeaseArray::ConstPtr &leases);
     void estopCallback(const spot_msgs::EStopStateArray::ConstPtr &estops);
+    void mobilityParamsCallback(const spot_msgs::MobilityParams::ConstPtr &params);
 
     ros::NodeHandle nh_;
     ros::ServiceClient sitService_;
@@ -64,6 +66,7 @@ class ControlPanel : public rviz::Panel
     ros::Publisher bodyPosePub_;
     ros::Subscriber leaseSub_;
     ros::Subscriber estopSub_;
+    ros::Subscriber mobilityParamsSub_;
 
     QPushButton* claimLeaseButton;
     QPushButton* releaseLeaseButton;
@@ -92,6 +95,8 @@ class ControlPanel : public rviz::Panel
     QDoubleSpinBox* rollSpin;
     QDoubleSpinBox* pitchSpin;
     QDoubleSpinBox* yawSpin;
+
+    spot_msgs::MobilityParams _lastMobilityParams;
 
     bool haveLease;
     bool isEStopped;

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -159,6 +159,7 @@ class ControlPanel : public rviz::Panel
     QLabel* batteryStateLabel;
     QLabel* motorStateLabel;
     QLabel* batteryTempLabel;
+    QLabel* estopLabel;
 
     QComboBox* gaitComboBox;
     QComboBox* swingHeightComboBox;

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -39,7 +39,7 @@ class ControlPanel : public rviz::Panel
     void setControlButtons();
     void toggleBodyPoseButtons();
     bool callTriggerService(ros::ServiceClient service, std::string serviceName);
-    void updateLabelTextWithLimit(QLabel* label, double limit, double limit_lower=0);
+    void updateLabelTextWithLimit(QLabel* label, double limit_lower, double limit_upper);
     void leaseCallback(const spot_msgs::LeaseArray::ConstPtr &leases);
 
     ros::NodeHandle nh_;

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -11,6 +11,8 @@
 #include <QLabel>
 #include <QDoubleSpinBox>
 #include <spot_msgs/LeaseArray.h>
+#include <spot_msgs/EStopStateArray.h>
+
 
 namespace spot_viz
 {
@@ -45,6 +47,7 @@ class ControlPanel : public rviz::Panel
     bool callTriggerService(ros::ServiceClient service, std::string serviceName);
     void updateLabelTextWithLimit(QLabel* label, double limit_lower, double limit_upper);
     void leaseCallback(const spot_msgs::LeaseArray::ConstPtr &leases);
+    void estopCallback(const spot_msgs::EStopStateArray::ConstPtr &estops);
 
     ros::NodeHandle nh_;
     ros::ServiceClient sitService_;
@@ -60,6 +63,7 @@ class ControlPanel : public rviz::Panel
     ros::ServiceClient stopService_;
     ros::Publisher bodyPosePub_;
     ros::Subscriber leaseSub_;
+    ros::Subscriber estopSub_;
 
     QPushButton* claimLeaseButton;
     QPushButton* releaseLeaseButton;
@@ -90,6 +94,7 @@ class ControlPanel : public rviz::Panel
     QDoubleSpinBox* yawSpin;
 
     bool haveLease;
+    bool isEStopped;
 };
 
 } // end namespace spot_viz

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -36,6 +36,7 @@ class ControlPanel : public rviz::Panel
     void gentleStop();
     void hardStop();
     void releaseStop();
+    void stop();
 
     private:
 
@@ -56,6 +57,7 @@ class ControlPanel : public rviz::Panel
     ros::ServiceClient hardStopService_;
     ros::ServiceClient gentleStopService_;
     ros::ServiceClient releaseStopService_;
+    ros::ServiceClient stopService_;
     ros::Publisher bodyPosePub_;
     ros::Subscriber leaseSub_;
 
@@ -70,6 +72,7 @@ class ControlPanel : public rviz::Panel
     QPushButton* hardStopButton;
     QPushButton* gentleStopButton;
     QPushButton* releaseStopButton;
+    QPushButton* stopButton;
     QLabel* linearXLabel;
     QLabel* linearYLabel;
     QLabel* angularZLabel;


### PR DESCRIPTION
See https://github.com/clearpathrobotics/spot_ros/pull/49 for some more detail about the initial commits of this PR. I have closed that one in favour of this one as it contains improvements on that initial PR.

# Summary
Safety improvements
- Param to disable autonomy on driver startup, cannot be changed without restarting driver
- Explicitly enable or disable all commands which can move the robot, with a service

Use more of the SDK
- Swing height
- Obstacle params
- Terrain params

Rviz improvements
- More of the messages output by the driver are used by the rviz interface for display (battery, power, estop status)
- Interface can send requests to modify more spot params

Bug workarounds
- Workaround for unknown trajectory command mentioned in #54
- Workaround for issue where low velocity limits (<0.1) cause trajectory commands to stall (this is an issue with BD's controls)

Other
- Set default velocity limits in the driver launch

![Screenshot from 2022-02-23 13-32-18](https://user-images.githubusercontent.com/636456/155329439-36d2a840-db4e-43d6-a965-e66e88711732.png)


# Safety Improvements

I have made a few changes to make it easier to enable or disable the autonomy and motion components that are available in the driver.

## Disabling autonomy

When developing custom code, I found it useful to have an explicit parameter which would enable or disable the autonomy components. At the moment that is the trajectory command, graph nav, and cmd_vel. These can all move the robot away from its current position. Commands like sit, stand, and various body posing commands do not move the robot, and I consider these to be non-autonomous.

This parameter is set at start of the system, and cannot be modified while the driver is running. This is to ensure that explicit action is required to switch the driver into autonomous mode.

With this parameter I could specify in a launch file if the autonomy was enabled, and if it was, start additional layers of safety which require other nodes to be launched.

If autonomy is not required, such as when moving the robot with the controller, the driver can be started with autonomy disabled, and provide a guarantee that the robot cannot be made to move autonomously.

To use the parameter, you can make a launch file something like

```xml
<launch>
    <arg name="autonomy_enabled" default="true"/>
    <include file="$(find spot_driver)/launch/driver.launch">
        <arg name="username" value="$(env SPOT_USER)"/>
        <arg name="password" value="$(env SPOT_PASSWORD)"/>
        <arg name="autonomy_enabled" value="$(arg autonomy)"/>
    </include>
</launch>
```

Autonomy is also disabled by the battery charge state. If the robot is charging, it is connected to shore power. Anything that moves the robot in the environment could cause tangling or damage to the charging system. I've added a check on the charge status which will prevent motion.

## Enabling/disabling motion

As an additional safety layer, I implemented a service that can be used to enable or disable all commands that allow the robot to move. This includes sit and stand commands.

With motion disabled, we can guarantee that the robot will not make any motion at all, useful in situations where the robot moving could be dangerous to either the robot or people.

This is particularly useful if you are rolling your own autonomy. The current implementation of the stop command will interrupt the current trajectory command, but autonomy may continue to send commands after the operator requests a stop. This feature means that we can interrupt and lock out any further motion commands.

The `/spot/allow_motion` service allows control of this with a `SetBool`:

```
rosservice call /spot/allow_motion false
success: True
message: "Spot motion was disabled"
```

Disabling motion will also interrupt any currently executing command.

In addition, there is a new stop service `/spot/locked_stop` which will disable motion and stop the current motion. To re-enable motion after calling that service, the `allow_motion` service must be called.

```
rosservice call /spot/allow_motion true 
success: True
message: "Spot motion was enabled"
```

# Additional SDK functionality exposed

There were some SDK components that were not in the driver which are exposed on the controller, which are now exposed in the driver.

## Swing height

The swing height of the legs can now be set using the `/spot/swing_height` service, which uses the new `SetSwingHeight` srv.

```
rossrv show spot_msgs/SetSwingHeight 
uint8 SWING_HEIGHT_UNKNOWN=0
uint8 SWING_HEIGHT_LOW=1
uint8 SWING_HEIGHT_MEDIUM=2
uint8 SWING_HEIGHT_HIGH=3
uint8 swing_height
---
bool success
string message
```

The mobility params message also includes the current swing height setting.

## Obstacle params

A start on including obstacle params in the settable components. Currently the only setting that can be adjusted is the obstacle padding. The obstacle params contain some things which could be pretty dangerous to disable. The parameter can be adjusted with the `/spot/obstacle_params` service, which uses `spot_msgs/SetObstacleParams`.

```
rossrv show spot_msgs/SetObstacleParams 
spot_msgs/ObstacleParams obstacle_params
  bool disable_vision_foot_obstacle_avoidance
  bool disable_vision_foot_constraint_avoidance
  bool disable_vision_body_obstacle_avoidance
  float32 obstacle_avoidance_padding
  bool disable_vision_foot_obstacle_body_assist
  bool disable_vision_negative_obstacles
---
bool success
string message
```

The mobility params message also includes the current obstacle params.

## Terrain params

Terrain params can now be set with the `/spot/terrain_params` service. This is the ground friction and the grated floor mode. It uses the `spot_msgs/SetTerrainParams` message.

```
rossrv show spot_msgs/SetTerrainParams 
spot_msgs/TerrainParams terrain_params
  uint8 GRATED_SURFACES_MODE_UNKNOWN=0
  uint8 GRATED_SURFACES_MODE_OFF=1
  uint8 GRATED_SURFACES_MODE_ON=2
  uint8 GRATED_SURFACES_MODE_AUTO=3
  float32 ground_mu_hint
  uint8 grated_surfaces_mode
---
bool success
string message
```

The current state of these params is also part of the mobility params output.

## Locomotion hint for gaits

The locomotion hint message now has constants from the sdk so that it is more obvious which value of the hint applies which gait.

```
uint8 HINT_UNKNOWN=0
uint8 HINT_AUTO=1
uint8 HINT_TROT=2
uint8 HINT_SPEED_SELECT_TROT=3
uint8 HINT_CRAWL=4
uint8 HINT_AMBLE=5
uint8 HINT_SPEED_SELECT_AMBLE=6
uint8 HINT_JOG=7
uint8 HINT_HOP=8
uint8 HINT_SPEED_SELECT_CRAWL=10
```

# Rviz improvements

## Tabs

The UI now has tabs for different things that can be adjusted. Currently these tabs are motion, advanced motion, and body. There is plenty of scope for rearranging things, but based on my usage I think the current layout makes sense.

### Motion

Contains the basic controls that I think are most commonly used - obstacle padding and velocity limits.

![Screenshot from 2022-02-17 12-06-35](https://user-images.githubusercontent.com/636456/154478573-5ce92aaa-7756-48ec-b0bb-2bec21dfba6b.png)

### Advanced motion

More advanced motion stuff is in here. That is gait settings, swing height settings, ground friction and grated floor modes. The default value in the combobox for these items is the same as the value on the controller. The mobility params message generated by the SDK does not fill in the default values, so I made the decision to display them here rather than showing "unknown".

![Screenshot from 2022-02-17 12-06-48](https://user-images.githubusercontent.com/636456/154478569-674e8972-6692-4350-8685-d1634d29d8ec.png)

### Body

The body pose control is now in this tab. As mentioned in my earlier PR, these settings only apply to body position when in motion, and do not give the same range of motion as the stand mode with the controller does. That will have to be implemented separately.

![Screenshot from 2022-02-17 12-06-59](https://user-images.githubusercontent.com/636456/154478567-910326f7-cbc0-417e-8d34-980951ef822b.png)


## Battery and power labels

The battery and power status topics are now read by the ui and used to display information about the battery and power states.

With battery present:

![Screenshot from 2022-02-17 12-16-31](https://user-images.githubusercontent.com/636456/154480047-8b6a3f58-0a5c-4a2a-945c-c4253566dc89.png)

Without battery:

![Screenshot from 2022-02-17 12-18-40](https://user-images.githubusercontent.com/636456/154480466-7587db1c-2980-41dc-ad8b-5522b85f9ac0.png)

## Display of current velocity limits

The velocity limits that are in the mobility params that the robot is currently using are now displayed in the boxes used to enter them. Previously this would display 0 until you changed it.

## Other

- Power off button is disabled when power is off, power on is disabled when power is on.
- Allow/disallow motion button is added, which enables or disables the stop button

![allow_disallow_motion_spot](https://user-images.githubusercontent.com/636456/154480879-84c08824-f198-4364-be6a-6bb1f3a009a4.gif)


# Bug workarounds

I have included my workaround for the unknown trajectory failures that I mentioned in #54.

I discovered an issue where setting low velocity limits (<0.1) would cause trajectory commands to stall. The workaround is simply to reject values for the velocity limits which have values which may cause issues. I have contacted BD support about this and provided them with log files, and they have confirmed that this is not an issue on the ROS side of things.

# Other changes

The velocity limits that are applied to motion can now be set as arguments in the driver launch file. This means that you can start the robot with some default limits.

```xml
    <include file="$(find spot_driver)/launch/driver.launch">
        <arg name="username" value="$(env SPOT_USER)"/>
        <arg name="password" value="$(env SPOT_PASSWORD)"/>
        <arg name="max_linear_velocity_x" value="0.5"/>
        <arg name="max_linear_velocity_y" value="0.5"/>
        <arg name="max_angular_velocity_z" value="0.5"/>
    </include>
```