### PR TITLE
Add real_front_rail joint which corresponds to position in payload mounting reference

### DIFF
--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -27,11 +27,25 @@
         <child link="front_rail" />
     </joint>
 
+    <link name="real_front_rail"/>
+    <joint name="real_front_rail_joint" type="fixed">
+        <origin xyz="0.2075 0 0.0805" rpy="0 0 0" />
+        <parent link="body" />
+        <child link="real_front_rail" />
+    </joint>
+
     <link name="rear_rail"/>
     <joint name="rear_rail_joint" type="fixed">
         <origin xyz="-0.223 0 0.0805" rpy="0 0 0" />
         <parent link="body" />
         <child link="rear_rail" />
+    </joint>
+
+    <link name="real_rear_rail"/>
+    <joint name="real_rear_rail_joint" type="fixed">
+        <origin xyz="-0.415 0 0" rpy="0 0 0" />
+        <parent link="real_front_rail" />
+        <child link="real_rear_rail" />
     </joint>
 
     <link name="front_left_hip">


### PR DESCRIPTION
See https://support.bostondynamics.com/s/article/Spot-robot-mounting-rails for details. The current front_rail is slightly offset forwards in the x direction from the actual expected position of the front rail, which makes it difficult to use that reference point when mounting payloads.

![Screenshot from 2022-05-11 16-33-31](https://user-images.githubusercontent.com/636456/167889501-639b3598-31ae-4d68-bd0d-280d2a03ab54.png)
