### PR TITLE
Only add camera tasks when needed

### DIFF
--- a/spot_driver/config/spot_ros.yaml
+++ b/spot_driver/config/spot_ros.yaml
@@ -12,6 +12,7 @@ rates:
   hand_image: 10.0
   feedback: 10.0
   mobility_params: 10.0
+  check_subscribers: 10.0
 auto_claim: False
 auto_power_on: False
 auto_stand: False

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -1312,7 +1312,6 @@ class SpotROS:
         self.motion_allowed_pub.publish(self.allow_motion)
 
     def check_for_subscriber(self):
-        # self.hand_image_mono_pub
         pubs = [
             self.back_image_pub,
             self.hand_image_color_pub,

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -1312,13 +1312,18 @@ class SpotROS:
         self.motion_allowed_pub.publish(self.allow_motion)
 
     def check_for_subscriber(self):
-        #self.hand_image_mono_pub
-        pubs = [self.back_image_pub, self.hand_image_color_pub, self.right_image_pub, self.left_image_pub]
+        # self.hand_image_mono_pub
+        pubs = [
+            self.back_image_pub,
+            self.hand_image_color_pub,
+            self.right_image_pub,
+            self.left_image_pub,
+        ]
         lookup = {
-            self.back_image_pub : "rear_image",
-            self.right_image_pub : "side_image",
-            self.left_image_pub : "side_image",
-            self.hand_image_color_pub : "hand_image",
+            self.back_image_pub: "rear_image",
+            self.right_image_pub: "side_image",
+            self.left_image_pub: "side_image",
+            self.hand_image_color_pub: "hand_image",
         }
         for pub in pubs:
             if pub.get_num_connections() > 0 and lookup[pub] not in self.added_tasks:

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -1313,7 +1313,7 @@ class SpotROS:
         self.motion_allowed_pub.publish(self.allow_motion)
 
     def check_for_subscriber(self):
-        for pub in list(self.lookup.keys()):
+        for pub in list(self.camera_pub_to_async_task_mapping.keys()):
             task_name = self.camera_pub_to_async_task_mapping[pub]
             if task_name not in self.added_tasks and pub.get_num_connections() > 0:
                 self.spot_wrapper.update_image_tasks(task_name)

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -1315,7 +1315,10 @@ class SpotROS:
     def check_for_subscriber(self):
         for pub in list(self.camera_pub_to_async_task_mapping.keys()):
             task_name = self.camera_pub_to_async_task_mapping[pub]
-            if task_name not in self.active_camera_tasks and pub.get_num_connections() > 0:
+            if (
+                task_name not in self.active_camera_tasks
+                and pub.get_num_connections() > 0
+            ):
                 self.spot_wrapper.update_image_tasks(task_name)
                 self.active_camera_tasks.append(task_name)
                 print(

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -1325,7 +1325,7 @@ class SpotROS:
             self.hand_image_color_pub: "hand_image",
         }
         for pub in pubs:
-            if pub.get_num_connections() > 0 and lookup[pub] not in self.added_tasks:
+            if lookup[pub] not in self.added_tasks and pub.get_num_connections() > 0:
                 self.spot_wrapper.update_image_tasks(lookup[pub])
                 self.added_tasks.append(lookup[pub])
                 print("Adding :", lookup[pub])

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -1315,7 +1315,7 @@ class SpotROS:
     def check_for_subscriber(self):
         for pub in list(self.camera_pub_to_async_task_mapping.keys()):
             task_name = self.camera_pub_to_async_task_mapping[pub]
-            if task_name not in self.added_tasks and pub.get_num_connections() > 0:
+            if task_name not in self.active_camera_tasks and pub.get_num_connections() > 0:
                 self.spot_wrapper.update_image_tasks(task_name)
                 self.active_camera_tasks.append(task_name)
                 print(

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -1829,4 +1829,3 @@ class SpotWrapper:
             self._async_tasks.add_task(self._hand_image_task)
 
         self._async_tasks.add_task(lookup[image_name])
-        

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -554,6 +554,12 @@ class SpotWrapper:
                 ]
             )
 
+            self.lookup = {
+                "hand_image": self._hand_image_task,
+                "side_image": self._side_image_task,
+                "rear_image": self._rear_image_task,
+            }
+
             self._robot_id = None
             self._lease = None
 
@@ -1820,12 +1826,7 @@ class SpotWrapper:
 
     def update_image_tasks(self, image_name):
         """Updates the async tasks for an image topic if there is a subscriber"""
-        lookup = {
-            "hand_image": self._hand_image_task,
-            "side_image": self._side_image_task,
-            "rear_image": self._rear_image_task,
-        }
         if self._robot.has_arm():
             self._async_tasks.add_task(self._hand_image_task)
 
-        self._async_tasks.add_task(lookup[image_name])
+        self._async_tasks.add_task(self.lookup[image_name])

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -1378,7 +1378,7 @@ class SpotWrapper:
                 arm_cartesian_command = arm_command_pb2.ArmCartesianCommand.Request(
                     root_frame_name=BODY_FRAME_NAME,
                     pose_trajectory_in_task=hand_trajectory,
-                    force_remain_near_current_joint_configuration=True
+                    force_remain_near_current_joint_configuration=True,
                 )
                 arm_command = arm_command_pb2.ArmCommand.Request(
                     arm_cartesian_command=arm_cartesian_command
@@ -1821,13 +1821,11 @@ class SpotWrapper:
     def update_image_tasks(self, image_name):
         """Updates the async tasks for an image topic if there is a subscriber"""
         lookup = {
-            "hand_image" : self._hand_image_task,
-            "side_image" : self._side_image_task,
-            "rear_image" :self._rear_image_task,
-        
+            "hand_image": self._hand_image_task,
+            "side_image": self._side_image_task,
+            "rear_image": self._rear_image_task,
         }
         if self._robot.has_arm():
-                self._async_tasks.add_task(self._hand_image_task)
+            self._async_tasks.add_task(self._hand_image_task)
 
         self._async_tasks.add_task(lookup[image_name])
-        

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -1829,3 +1829,4 @@ class SpotWrapper:
             self._async_tasks.add_task(self._hand_image_task)
 
         self._async_tasks.add_task(lookup[image_name])
+        

--- a/spot_driver/src/spot_driver/spot_wrapper.py
+++ b/spot_driver/src/spot_driver/spot_wrapper.py
@@ -1839,7 +1839,7 @@ class SpotWrapper:
             )
             return
 
-        if task_to_add in self._async_tasks:
+        if task_to_add in self._async_tasks._tasks:
             self._logger.warn(
                 "Task already in async task list, will not be added again"
             )


### PR DESCRIPTION
I have noticed that we add all camera tasks in the beginning even if there is nothing subscribing to it. This slows down the frequencies of the camera topics a lot. I have added a routine that checks for subscribers to a camera topic and only then adds the task. I have also cleared up some minor bugs that I have come across when working with the driver. All is tested on our spot