### PR TITLE
optionally publish parent odom tf

### DIFF
--- a/spot_driver/src/spot_driver/ros_helpers.py
+++ b/spot_driver/src/spot_driver/ros_helpers.py
@@ -452,7 +452,7 @@ def generate_feet_tf(foot_states_msg):
     return foot_tfs
 
 
-def GetTFFromState(state, spot_wrapper, inverse_target_frame):
+def GetTFFromState(state, spot_wrapper, inverse_target_frame, publish_odom_tf):
     """Maps robot link state data from robot state proto to ROS TFMessage message
 
     Args:
@@ -471,6 +471,8 @@ def GetTFFromState(state, spot_wrapper, inverse_target_frame):
             frame_name
         ).parent_frame_name:
             try:
+                if inverse_target_frame == frame_name and publish_odom_tf == False:
+                    continue
                 transform = state.kinematic_state.transforms_snapshot.child_to_parent_edge_map.get(
                     frame_name
                 )

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -126,7 +126,12 @@ class SpotROS:
             self.joint_state_pub.publish(joint_state)
 
             ## TF ##
-            tf_msg = GetTFFromState(state, self.spot_wrapper, self.mode_parent_odom_tf)
+            tf_msg = GetTFFromState(
+                state,
+                self.spot_wrapper,
+                self.mode_parent_odom_tf,
+                self.publish_parent_odom_tf
+            )
             if len(tf_msg.transforms) > 0:
                 self.tf_pub.publish(tf_msg)
 
@@ -1420,6 +1425,7 @@ class SpotROS:
         self.estop_timeout = rospy.get_param("~estop_timeout", 9.0)
         self.autonomy_enabled = rospy.get_param("~autonomy_enabled", True)
         self.allow_motion = rospy.get_param("~allow_motion", True)
+        self.publish_parent_odom_tf = rospy.get_param('~publish_parent_odom_tf', True)
         self.is_charging = False
 
         self.tf_buffer = tf2_ros.Buffer()


### PR DESCRIPTION
This supports case where a payload publishes map and odom frames and doesn't want the platform interfering.