### PR TITLE
Docking, self-right and roll over accessible from Rviz, docking/undocking actionserver

### DIFF
--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -1715,7 +1715,7 @@ class SpotROS:
         self.body_pose_as.start()
 
         self.dock_as = actionlib.SimpleActionServer(
-            "body_pose",
+            "dock",
             DockAction,
             execute_cb=self.handle_dock_action,
             auto_start=False,

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -59,6 +59,7 @@ add_service_files(
 
 add_action_files(
   FILES
+  Dock.action
   NavigateTo.action
   PoseBody.action
   Trajectory.action

--- a/spot_msgs/action/Dock.action
+++ b/spot_msgs/action/Dock.action
@@ -1,0 +1,10 @@
+# Dock at the dock with this fiducial ID
+uint32 dock_id
+
+# If true, undock instead of docking
+bool undock
+---
+bool success
+string message
+---
+DockState status

--- a/spot_viz/resource/spot_control.ui
+++ b/spot_viz/resource/spot_control.ui
@@ -244,6 +244,12 @@
      </item>
      <item>
       <widget class="QTabWidget" name="tabWidget">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
        <property name="currentIndex">
         <number>0</number>
        </property>
@@ -389,7 +395,248 @@
          </item>
         </layout>
        </widget>
+       <widget class="QWidget" name="dockingTab">
+        <attribute name="title">
+         <string>Dock</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_7">
+         <item>
+          <layout class="QVBoxLayout" name="dockingLayout">
+           <item>
+            <widget class="QPushButton" name="undockButton">
+             <property name="text">
+              <string>Undock</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="dockSelectLayout">
+             <item>
+              <widget class="QLabel" name="dockLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="layoutDirection">
+                <enum>Qt::LeftToRight</enum>
+               </property>
+               <property name="text">
+                <string>Dock fiducial ID</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="dockFiducialSpin">
+               <property name="minimum">
+                <number>520</number>
+               </property>
+               <property name="maximum">
+                <number>549</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="dockButton">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Dock</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="bodyTab">
+        <attribute name="title">
+         <string>Body</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <layout class="QGridLayout" name="bodyPoseGridLayout">
+           <item row="5" column="1">
+            <widget class="QDoubleSpinBox" name="yawSpin">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="pitchLabel">
+             <property name="text">
+              <string>Pitch</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QDoubleSpinBox" name="pitchSpin">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QDoubleSpinBox" name="bodyHeightSpin">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="decimals">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="rollLabel">
+             <property name="text">
+              <string>Roll</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="yawLabel">
+             <property name="text">
+              <string>Yaw</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0" colspan="2">
+            <widget class="QPushButton" name="setBodyPoseButton">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Set Body Pose</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QDoubleSpinBox" name="rollSpin">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QLabel" name="bodyPoseLabel">
+             <property name="text">
+              <string>Body Pose Control</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="bodyHeightLabel">
+             <property name="text">
+              <string>Body height</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0" colspan="2">
+            <widget class="QPushButton" name="setBodyNeutralButton">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Return to Neutral Pose</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="floorTab">
+        <attribute name="title">
+         <string>Floor</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <item>
+          <layout class="QVBoxLayout" name="floorLayout">
+           <item>
+            <widget class="QPushButton" name="selfRightButton">
+             <property name="text">
+              <string>Self-right</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="0" column="0">
+              <widget class="QLabel" name="rollOverLabel">
+               <property name="text">
+                <string>Roll over</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QPushButton" name="rollOverRightButton">
+               <property name="text">
+                <string>Right</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QPushButton" name="rollOverLeftButton">
+               <property name="text">
+                <string>Left</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
        <widget class="QWidget" name="advancedMotionTab">
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
         <attribute name="title">
          <string>Adv. Motion</string>
         </attribute>
@@ -537,124 +784,6 @@
               </widget>
              </item>
             </layout>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="bodyTab">
-        <attribute name="title">
-         <string>Body</string>
-        </attribute>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
-          <layout class="QGridLayout" name="bodyPoseGridLayout">
-           <item row="5" column="1">
-            <widget class="QDoubleSpinBox" name="yawSpin">
-             <property name="buttonSymbols">
-              <enum>QAbstractSpinBox::NoButtons</enum>
-             </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="pitchLabel">
-             <property name="text">
-              <string>Pitch</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QDoubleSpinBox" name="pitchSpin">
-             <property name="buttonSymbols">
-              <enum>QAbstractSpinBox::NoButtons</enum>
-             </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QDoubleSpinBox" name="bodyHeightSpin">
-             <property name="buttonSymbols">
-              <enum>QAbstractSpinBox::NoButtons</enum>
-             </property>
-             <property name="decimals">
-              <number>2</number>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="rollLabel">
-             <property name="text">
-              <string>Roll</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="yawLabel">
-             <property name="text">
-              <string>Yaw</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0" colspan="2">
-            <widget class="QPushButton" name="setBodyPoseButton">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string>Set Body Pose</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QDoubleSpinBox" name="rollSpin">
-             <property name="buttonSymbols">
-              <enum>QAbstractSpinBox::NoButtons</enum>
-             </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0" colspan="2">
-            <widget class="QLabel" name="bodyPoseLabel">
-             <property name="text">
-              <string>Body Pose Control</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="bodyHeightLabel">
-             <property name="text">
-              <string>Body height</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="0" colspan="2">
-            <widget class="QPushButton" name="setBodyNeutralButton">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string>Return to Neutral Pose</string>
-             </property>
-            </widget>
            </item>
           </layout>
          </item>

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -19,6 +19,7 @@
 #include <spot_msgs/SetObstacleParams.h>
 #include <spot_msgs/SetTerrainParams.h>
 #include <spot_msgs/PosedStand.h>
+#include <spot_msgs/Dock.h>
 #include <string.h>
 
 
@@ -57,6 +58,11 @@ namespace spot_viz
         obstacleParamsService_ = nh_.serviceClient<spot_msgs::SetObstacleParams>("/spot/obstacle_params");
         allowMotionService_ = nh_.serviceClient<std_srvs::SetBool>("/spot/allow_motion");
         bodyPoseService_ = nh_.serviceClient<spot_msgs::PosedStand>("/spot/posed_stand");
+        dockService_ = nh_.serviceClient<spot_msgs::Dock>("/spot/dock");
+        undockService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/undock");
+        selfRightService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/self_right");
+        rollOverRightService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/roll_over_right");
+        rollOverLeftService_ = nh_.serviceClient<std_srvs::Trigger>("/spot/roll_over_left");
 
         claimLeaseButton = this->findChild<QPushButton*>("claimLeaseButton");
         releaseLeaseButton = this->findChild<QPushButton*>("releaseLeaseButton");
@@ -72,7 +78,11 @@ namespace spot_viz
         setObstaclePaddingButton = this->findChild<QPushButton*>("setObstaclePaddingButton");
         setGratedSurfacesButton = this->findChild<QPushButton*>("setGratedSurfacesButton");
         setFrictionButton = this->findChild<QPushButton*>("setFrictionButton");
-        allowMotionButton = this->findChild<QPushButton*>("allowMotionButton");
+        dockButton = this->findChild<QPushButton*>("dockButton");
+        undockButton = this->findChild<QPushButton*>("undockButton");
+        selfRightButton = this->findChild<QPushButton*>("selfRightButton");
+        rollOverLeftButton = this->findChild<QPushButton*>("rollOverLeftButton");
+        rollOverRightButton = this->findChild<QPushButton*>("rollOverRightButton");
 
         statusLabel = this->findChild<QLabel*>("statusLabel");
         estimatedRuntimeLabel = this->findChild<QLabel*>("estimatedRuntimeLabel");
@@ -87,6 +97,8 @@ namespace spot_viz
 
         obstaclePaddingSpin = this->findChild<QDoubleSpinBox*>("obstaclePaddingSpin");
         frictionSpin = this->findChild<QDoubleSpinBox*>("frictionSpin");
+
+        dockFiducialSpin = this->findChild<QSpinBox*>("dockFiducialSpin");
 
         setupComboBoxes();
         setupStopButtons();
@@ -635,6 +647,28 @@ namespace spot_viz
         spot_msgs::SetObstacleParams req;
         req.request.obstacle_params.obstacle_avoidance_padding = obstaclePaddingSpin->value();
         callCustomTriggerService(obstacleParamsService_, "set obstacle params", req);
+    }
+
+    void ControlPanel::undock() {
+        callTriggerService(selfRightService_, "undock");
+    }
+
+    void ControlPanel::dock() {
+        spot_msgs::Dock req;
+        req.request.dock_id = dockFiducialSpin->value();
+        callCustomTriggerService(dockService_, "dock", req);
+    }
+
+    void ControlPanel::selfRight() {
+        callTriggerService(selfRightService_, "self right");
+    }
+
+    void ControlPanel::rollOverLeft() {
+        callTriggerService(rollOverLeftService_, "roll over left");
+    }
+
+    void ControlPanel::rollOverRight() {
+        callTriggerService(rollOverRightService_, "roll over left");
     }
 
     void ControlPanel::save(rviz::Config config) const

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -78,6 +78,7 @@ namespace spot_viz
         setObstaclePaddingButton = this->findChild<QPushButton*>("setObstaclePaddingButton");
         setGratedSurfacesButton = this->findChild<QPushButton*>("setGratedSurfacesButton");
         setFrictionButton = this->findChild<QPushButton*>("setFrictionButton");
+        allowMotionButton = this->findChild<QPushButton*>("allowMotionButton");
         dockButton = this->findChild<QPushButton*>("dockButton");
         undockButton = this->findChild<QPushButton*>("undockButton");
         selfRightButton = this->findChild<QPushButton*>("selfRightButton");
@@ -131,6 +132,11 @@ namespace spot_viz
         connect(setGratedSurfacesButton, SIGNAL(clicked()), this, SLOT(setTerrainParams()));
         connect(setFrictionButton, SIGNAL(clicked()), this, SLOT(setTerrainParams()));
         connect(allowMotionButton, SIGNAL(clicked()), this, SLOT(allowMotion()));
+        connect(dockButton, SIGNAL(clicked()), this, SLOT(dock()));
+        connect(undockButton, SIGNAL(clicked()), this, SLOT(undock()));
+        connect(selfRightButton, SIGNAL(clicked()), this, SLOT(selfRight()));
+        connect(rollOverLeftButton, SIGNAL(clicked()), this, SLOT(rollOverLeft()));
+        connect(rollOverRightButton, SIGNAL(clicked()), this, SLOT(rollOverRight()));
     }
 
     void ControlPanel::setupStopButtons() {
@@ -269,6 +275,11 @@ namespace spot_viz
         setFrictionButton->setEnabled(haveLease);
         setGratedSurfacesButton->setEnabled(haveLease);
         allowMotionButton->setEnabled(haveLease);
+        dockButton->setEnabled(haveLease);
+        undockButton->setEnabled(haveLease);
+        selfRightButton->setEnabled(haveLease);
+        rollOverLeftButton->setEnabled(haveLease);
+        rollOverRightButton->setEnabled(haveLease);
     }
 
     /**
@@ -650,7 +661,7 @@ namespace spot_viz
     }
 
     void ControlPanel::undock() {
-        callTriggerService(selfRightService_, "undock");
+        callTriggerService(undockService_, "undock");
     }
 
     void ControlPanel::dock() {

--- a/spot_viz/src/spot_panel.hpp
+++ b/spot_viz/src/spot_panel.hpp
@@ -54,6 +54,11 @@ class ControlPanel : public rviz::Panel
     void setTerrainParams();
     void setObstacleParams();
     void allowMotion();
+    void rollOverRight();
+    void rollOverLeft();
+    void selfRight();
+    void dock();
+    void undock();
 
     private:
 
@@ -121,6 +126,11 @@ class ControlPanel : public rviz::Panel
     ros::ServiceClient obstacleParamsService_;
     ros::ServiceClient allowMotionService_;
     ros::ServiceClient bodyPoseService_;
+    ros::ServiceClient dockService_;
+    ros::ServiceClient undockService_;
+    ros::ServiceClient selfRightService_;
+    ros::ServiceClient rollOverLeftService_;
+    ros::ServiceClient rollOverRightService_;
 
     ros::Subscriber leaseSub_;
     ros::Subscriber estopSub_;
@@ -148,6 +158,11 @@ class ControlPanel : public rviz::Panel
     QPushButton* setGratedSurfacesButton;
     QPushButton* setFrictionButton;
     QPushButton* allowMotionButton;
+    QPushButton* dockButton;
+    QPushButton* undockButton;
+    QPushButton* selfRightButton;
+    QPushButton* rollOverLeftButton;
+    QPushButton* rollOverRightButton;
 
     QLabel* linearXLabel;
     QLabel* linearYLabel;
@@ -166,6 +181,8 @@ class ControlPanel : public rviz::Panel
     QComboBox* gaitComboBox;
     QComboBox* swingHeightComboBox;
     QComboBox* gratedSurfacesComboBox;
+
+    QSpinBox* dockFiducialSpin;
 
     QDoubleSpinBox* linearXSpin;
     QDoubleSpinBox* linearYSpin;


### PR DESCRIPTION
This completes GUI access for most of the commands the robot can perform, as well as adding a dock/undock actionserver.

Both button and actionserver functionality tested on our spot.

Currently the spinbox to enter docking fiducial IDs is limited to values between 520 and 549, which is the value range reserved for docking stations, and for which fiducial stickers are provided along with the dock.

Any feedback appreciated.