### PR TITLE
subscriber check now polls also depth/info topics

### DIFF
--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -1556,14 +1556,6 @@ class SpotROS:
         self.point_cloud_pub = rospy.Publisher(
             "lidar/points", PointCloud2, queue_size=10
         )
-        self.camera_pub_to_async_task_mapping = {
-            self.frontleft_image_pub: "front_image",
-            self.frontright_image_pub: "front_image",
-            self.back_image_pub: "rear_image",
-            self.right_image_pub: "side_image",
-            self.left_image_pub: "side_image",
-            self.hand_image_color_pub: "hand_image",
-        }
 
         # Image Camera Info #
         self.back_image_info_pub = rospy.Publisher(
@@ -1616,6 +1608,29 @@ class SpotROS:
         self.frontright_depth_in_visual_info_pub = rospy.Publisher(
             "depth/frontright/depth_in_visual/camera_info", CameraInfo, queue_size=10
         )
+
+        self.camera_pub_to_async_task_mapping = {
+            self.frontleft_image_pub: "front_image",
+            self.frontleft_depth_pub: "front_image",
+            self.frontleft_image_info_pub: "front_image",
+            self.frontright_image_pub: "front_image",
+            self.frontright_depth_pub: "front_image",
+            self.frontright_image_info_pub: "front_image",
+            self.back_image_pub: "rear_image",
+            self.back_depth_pub: "rear_image",
+            self.back_image_info_pub: "rear_image",
+            self.right_image_pub: "side_image",
+            self.right_depth_pub: "side_image",
+            self.right_image_info_pub: "side_image",
+            self.left_image_pub: "side_image",
+            self.left_depth_pub: "side_image",
+            self.left_image_info_pub: "side_image",
+            self.hand_image_color_pub: "hand_image",
+            self.hand_image_mono_pub: "hand_image",
+            self.hand_image_mono_info_pub: "hand_image",
+            self.hand_depth_pub: "hand_image",
+            self.hand_depth_in_hand_color_pub: "hand_image",
+        }
 
         # Status Publishers #
         self.joint_state_pub = rospy.Publisher(


### PR DESCRIPTION
Fixes the publishing request of the depth cameras, see #115. Now if one tries to subscribe to the camera/depth/info topic of any of the depth cameras, the topics are published correctly. Tested on SpotCORE with a docker container with ROS noetic.