### PR TITLE
Add odometry topic which outputs twist in correct frame

### DIFF
--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -157,11 +157,16 @@ class SpotROS:
             self.odom_twist_pub.publish(twist_odom_msg)
 
             # Odom #
-            if self.mode_parent_odom_tf == "vision":
-                odom_msg = GetOdomFromState(state, self.spot_wrapper, use_vision=True)
-            else:
-                odom_msg = GetOdomFromState(state, self.spot_wrapper, use_vision=False)
+            use_vision = self.mode_parent_odom_tf == "vision"
+            odom_msg = GetOdomFromState(
+                state,
+                self.spot_wrapper,
+                use_vision=use_vision,
+            )
             self.odom_pub.publish(odom_msg)
+
+            odom_corrected_msg = get_corrected_odom(odom_msg)
+            self.odom_corrected_pub.publish(odom_corrected_msg)
 
             # Feet #
             foot_array_msg = GetFeetFromState(state, self.spot_wrapper)
@@ -1629,6 +1634,9 @@ class SpotROS:
             "odometry/twist", TwistWithCovarianceStamped, queue_size=10
         )
         self.odom_pub = rospy.Publisher("odometry", Odometry, queue_size=10)
+        self.odom_corrected_pub = rospy.Publisher(
+            "odometry_corrected", Odometry, queue_size=10
+        )
         self.feet_pub = rospy.Publisher("status/feet", FootStateArray, queue_size=10)
         self.estop_pub = rospy.Publisher("status/estop", EStopStateArray, queue_size=10)
         self.wifi_pub = rospy.Publisher("status/wifi", WiFiState, queue_size=10)


### PR DESCRIPTION
The default odometry topic has the twist portion in the odom frame and not the body frame. This is because the robot generates it in that way (https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference#kinematicstate). This causes problems with ROS components which expect the twist to be in the child_frame_id. 

This PR adds a topic `/spot/odometry_corrected` which has the twist in the correct frame, fixing #95.