### PR TITLE
Added section to catch velocity limits set to 0

### DIFF
--- a/spot_driver/launch/driver.launch
+++ b/spot_driver/launch/driver.launch
@@ -4,10 +4,10 @@
   <arg name="hostname" default="192.168.50.3" />
   <arg name="estop_timeout" default="9.0"/>
   <arg name="autonomy_enabled" default="true"/>
-  <!-- In m/s. 0 applies spot's internal limits -->
-  <arg name="max_linear_velocity_x" default="0"/>
-  <arg name="max_linear_velocity_y" default="0"/>
-  <arg name="max_angular_velocity_z" default="0"/>
+  <!-- In m/s.  -->
+  <arg name="max_linear_velocity_x" default="0.5"/>
+  <arg name="max_linear_velocity_y" default="0.5"/>
+  <arg name="max_angular_velocity_z" default="0.5"/>
   <arg name="allow_motion" default="true"/>
   <arg name="driver_config" default="$(find spot_driver)/config/spot_ros.yaml"/>
 

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -827,6 +827,19 @@ class SpotROS:
             )
             return
 
+        mobility_params = self.spot_wrapper.get_mobility_params()
+        max_lin_vel_x=mobility_params.vel_limit.max_vel.linear.x
+        max_lin_vel_y=mobility_params.vel_limit.max_vel.linear.y
+        max_angular_vel=mobility_params.vel_limit.max_vel.angular
+        if max_lin_vel_x==0 or max_lin_vel_y==0 or max_angular_vel==0:
+            rospy.logerr(
+                "Spot will not move as one or more of its velocity limits are set to 0. "
+                )
+            self.trajectory_server.set_aborted(
+                TrajectoryResult(False, "Velocity limits are set to 0.")
+            )
+            return
+
         target_pose = req.target_pose
         if req.target_pose.header.frame_id != "body":
             rospy.logwarn("Pose given was not in the body frame, will transform")

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -828,13 +828,14 @@ class SpotROS:
             return
 
         mobility_params = self.spot_wrapper.get_mobility_params()
-        max_lin_vel_x=mobility_params.vel_limit.max_vel.linear.x
-        max_lin_vel_y=mobility_params.vel_limit.max_vel.linear.y
-        max_angular_vel=mobility_params.vel_limit.max_vel.angular
-        if max_lin_vel_x==0 or max_lin_vel_y==0 or max_angular_vel==0:
+        if (
+            mobility_params.vel_limit.max_vel.linear.x == 0
+            or mobility_params.vel_limit.max_vel.linear.y == 0
+            or mobility_params.vel_limit.max_vel.angular == 0
+        ):
             rospy.logerr(
                 "Spot will not move as one or more of its velocity limits are set to 0. "
-                )
+            )
             self.trajectory_server.set_aborted(
                 TrajectoryResult(False, "Velocity limits are set to 0.")
             )


### PR DESCRIPTION
Raises an error if a trajectory command is sent whilst the linear x and y or angular z speed are equal to 0