### PR TITLE
ensure correct dependencies get passed along to downstream packages

### DIFF
--- a/spot_cam/CMakeLists.txt
+++ b/spot_cam/CMakeLists.txt
@@ -61,7 +61,7 @@ generate_messages(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES spot_cam
-  CATKIN_DEPENDS message_runtime
+  CATKIN_DEPENDS message_runtime std_msgs spot_msgs geometry_msgs
 #  DEPENDS system_lib
 )
 

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -93,7 +93,7 @@ generate_messages(
 )
 
 catkin_package(
-  CATKIN_DEPENDS message_runtime actionlib
+  CATKIN_DEPENDS message_runtime actionlib std_msgs sensor_msgs geometry_msgs
 )
 
 include_directories(


### PR DESCRIPTION
Building spot_cam failed with 

```                                                                                                                                                  
CMake Error at /opt/ros/noetic/share/genmsg/cmake/genmsg-extras.cmake:263 (message):
  Messages depends on unknown pkg: sensor_msgs (Missing
  'find_package(sensor_msgs)'?)
Call Stack (most recent call first):
  CMakeLists.txt:54 (generate_messages)
```

due to dependencies not being passed down from the spot_msgs package to the spot_cam package.

This PR includes changes necessary for dependencies of the spot_cam package to be used in further downstream packages too.