### PR TITLE
Update CMakeLists.txt, adding dependence of sensor_msgs

### DIFF
--- a/spot_cam/CMakeLists.txt
+++ b/spot_cam/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   spot_driver
   geometry_msgs
   message_generation
+  sensor_msgs
 )
 
 catkin_python_setup()
@@ -56,6 +57,7 @@ generate_messages(
   std_msgs
   spot_msgs
   geometry_msgs
+  sensor_msgs
 )
 
 catkin_package(


### PR DESCRIPTION
When compiling `spot_cam` with `catkin_make` in ROS `noetic`, the following error appeared:
```
Make Error at /opt/ros/noetic/share/genmsg/cmake/genmsg-extras.cmake:263 (message):
  Messages depends on unknown pkg: sensor_msgs (Missing
  'find_package(sensor_msgs)'?)
Call Stack (most recent call first):
  spot_ros/spot_cam/CMakeLists.txt:54 (generate_messages)
```
I just added the dependece in `find_package` and the problem was solved.