### PR TITLE
Use class_list_macros.hpp instead of deprecated .h

### DIFF
--- a/spot_viz/src/look_at_point_tool.cpp
+++ b/spot_viz/src/look_at_point_tool.cpp
@@ -91,5 +91,5 @@ int LookAtPointTool::processMouseEvent(rviz::ViewportMouseEvent &event) {
 
 } // namespace spot_viz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(spot_viz::LookAtPointTool, rviz::Tool)

--- a/spot_viz/src/spot_panel.cpp
+++ b/spot_viz/src/spot_panel.cpp
@@ -795,6 +795,6 @@ namespace spot_viz
     }
 } // end namespace spot_viz
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(spot_viz::ControlPanel, rviz::Panel)
 // END_TUTORIAL


### PR DESCRIPTION
The .h is removed entirely in `pluginlib-dev` in newer ubuntu/debian versions (https://packages.debian.org/bookworm/all/pluginlib-dev/filelist)